### PR TITLE
PR para correção no retorno dos generos na rota pública de retorno das novels

### DIFF
--- a/TsundokuTraducoes.Data/Repositories/ObrasRepository.cs
+++ b/TsundokuTraducoes.Data/Repositories/ObrasRepository.cs
@@ -25,7 +25,11 @@ namespace TsundokuTraducoes.Data.Repositories
 
             if (!string.IsNullOrEmpty(requestObras.Pesquisar))
             {                
-                listaNovels = await _context.Novels.AsNoTracking().Where(w => EF.Functions.Like(w.Titulo.ToUpper(), $"%{requestObras.Pesquisar.ToUpper()}%")).ToListAsync();
+                listaNovels = await _context.Novels
+                    .AsNoTracking()
+                    .Include(n => n.GenerosNovel)
+                    .ThenInclude(x => x.Genero)
+                    .Where(w => EF.Functions.Like(w.Titulo.ToUpper(), $"%{requestObras.Pesquisar.ToUpper()}%")).ToListAsync();
             }
             else
             {
@@ -33,11 +37,19 @@ namespace TsundokuTraducoes.Data.Repositories
                 if (parametrosVerificados)
                 {
                     var sql = RetornaSqlListaNovelsPorParametros(requestObras.Nacionalidade, requestObras.Status, requestObras.Tipo, requestObras.Genero);
-                    listaNovels = await _context.Novels.FromSqlRaw(sql).ToListAsync();
+                    listaNovels = await _context.Novels
+                        .FromSqlRaw(sql)
+                        .Include(n => n.GenerosNovel)
+                        .ThenInclude(x => x.Genero)
+                        .ToListAsync();
                 }
                 else
                 {
-                    listaNovels = await _context.Novels.ToListAsync();
+                    listaNovels = await _context.Novels
+                        .AsNoTracking()
+                        .Include(n => n.GenerosNovel)
+                        .ThenInclude(x => x.Genero)
+                        .ToListAsync();
                 }
             }
 

--- a/TsundokuTraducoes.Tests/Infrastructure/Data/Repositories/ObrasRepositoryFactory.cs
+++ b/TsundokuTraducoes.Tests/Infrastructure/Data/Repositories/ObrasRepositoryFactory.cs
@@ -1,0 +1,14 @@
+﻿using AutoFixture;
+using TsundokuTraducoes.Entities.Entities.Generos;
+using TsundokuTraducoes.Tests.Utils;
+
+namespace TsundokuTraducoes.Tests.Infrastructure.Data.Repositories
+{
+    public class ObrasRepositoryFactory()
+    {
+        public Genero GerarGenero(string genero)
+        {
+            return FixtureCustomizado.RetornaFixtureCustomizado.Build<Genero>().With(x => x.Descricao, genero).Create();
+        }
+    }
+}

--- a/TsundokuTraducoes.Tests/Infrastructure/Data/Repositories/ObrasRepositoryTestes.cs
+++ b/TsundokuTraducoes.Tests/Infrastructure/Data/Repositories/ObrasRepositoryTestes.cs
@@ -1,10 +1,14 @@
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
 using TsundokuTraducoes.Data.Context;
 using TsundokuTraducoes.Data.Repositories;
 using TsundokuTraducoes.Domain.Interfaces.Repositories;
+using TsundokuTraducoes.Domain.Services;
+using TsundokuTraducoes.Entities.Entities.Generos;
 using TsundokuTraducoes.Entities.Entities.Obra;
 using TsundokuTraducoes.Helpers;
-using TsundokuTraducoes.Domain.Services;
+using TsundokuTraducoes.Helpers.DTOs.Public.Request;
+using TsundokuTraducoes.Tests.Infrastructure.Data.Repositories;
 
 namespace TsundokuTraducoes.Infrastructure.Data.Repositories;
 
@@ -370,5 +374,107 @@ public class ObrasRepositoryTestes
         Assert.Equal("Hatsukoi Losstime", resultado.Titulo);
         Assert.Equal("Mangá", resultado.TipoObra);
         Assert.Equal("Nishina Yuuki", resultado.Autor);
+    }
+
+    [Fact]
+    public async Task ObterListaNovel_ComUmGenero_DeveRetornarComGeneroEsperado()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var novel = GerarNovel();
+        var obrasRepositoryMock = new ObrasRepositoryFactory();
+        novel.Id = id;
+        var genero = obrasRepositoryMock.GerarGenero("Fantasia");
+
+        var options = new DbContextOptionsBuilder<ContextBase>()
+            .UseInMemoryDatabase(databaseName: "TestDatabase")
+            .Options;
+
+        await using (var context = new ContextBase(options))
+        {
+            IObraRepository repositoryAdmin = new ObraRepository
+                (context,
+                new GeneroDeParaRepository(context),
+                new GeneroRepository(context));
+
+            var serviceAdmin = new ObraService(repositoryAdmin);
+            await context.Generos.AddAsync(genero);
+            await context.SaveChangesAsync();
+
+            await serviceAdmin.AdicionaNovel(novel);
+            await serviceAdmin.InsereGenerosNovel(novel, ["Fantasia"], true);
+
+            // Act
+            var repositoryPublic = new ObrasRepository(context);
+            var resultado = await repositoryPublic.ObterListaNovels(new RequestObras());
+
+            // Assert
+            Assert.True(resultado.Any());
+            Assert.Equal(id, resultado[0].Id);
+            Assert.Equal("Fantasia", resultado[0].ListaGeneros[0]);
+        }
+
+        await using (var context = new ContextBase(options))
+        {
+            await context.Database.EnsureDeletedAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ObterListaNovel_ComListaGenero_DeveRetornarComGenerosEsperados()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var novel = GerarNovel();
+        var obrasRepositoryMock = new ObrasRepositoryFactory();
+        novel.Id = id;
+
+        List<string> listaGeneros = ["Fantasia", "Aventure", "Seinen"];        
+        var generosMockados = new List<Genero>();
+
+        foreach (var genero in listaGeneros)
+        {
+            generosMockados.Add(obrasRepositoryMock.GerarGenero(genero));
+        }
+
+        var options = new DbContextOptionsBuilder<ContextBase>()
+            .UseInMemoryDatabase(databaseName: "TestDatabase")
+            .Options;
+
+        await using (var context = new ContextBase(options))
+        {
+            IObraRepository repositoryAdmin = new ObraRepository
+                (context,
+                new GeneroDeParaRepository(context),
+                new GeneroRepository(context));
+
+            var serviceAdmin = new ObraService(repositoryAdmin);
+
+            foreach (var genero in generosMockados)
+            {
+                await context.Generos.AddAsync(genero);
+                await context.SaveChangesAsync();
+            }            
+
+            await serviceAdmin.AdicionaNovel(novel);
+            await serviceAdmin.InsereGenerosNovel(novel, listaGeneros, true);
+
+
+            // Act
+            var repositoryPublic = new ObrasRepository(context);
+            var resultado = await repositoryPublic.ObterListaNovels(new RequestObras());
+
+            // Assert
+            Assert.True(resultado.Any());
+            Assert.Equal(id, resultado[0].Id);
+            Assert.Contains(listaGeneros[0], resultado[0].ListaGeneros);
+            Assert.Contains(listaGeneros[1], resultado[0].ListaGeneros);
+            Assert.Contains(listaGeneros[2], resultado[0].ListaGeneros);
+        }
+
+        await using (var context = new ContextBase(options))
+        {
+            await context.Database.EnsureDeletedAsync();
+        }
     }
 }

--- a/TsundokuTraducoes.Tests/TsundokuTraducoes.Tests.csproj
+++ b/TsundokuTraducoes.Tests/TsundokuTraducoes.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />

--- a/TsundokuTraducoes.Tests/Utils/FixtureCustomization.cs
+++ b/TsundokuTraducoes.Tests/Utils/FixtureCustomization.cs
@@ -1,0 +1,63 @@
+﻿using AutoFixture;
+using AutoFixture.Kernel;
+using System.Reflection;
+
+namespace TsundokuTraducoes.Tests.Utils
+{
+    public static class FixtureCustomizado
+    {
+        public static Fixture RetornaFixtureCustomizado
+        {
+            get
+            {
+                var fixture = new Fixture();
+                fixture.Customize(new NoCircularReferencesCustomization());
+                fixture.Customize(new IgnoreVirtualMembersCustomization());
+
+                return fixture;
+            }
+        }
+    }
+
+    public class NoCircularReferencesCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+            fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
+                .ForEach(behavior => fixture.Behaviors.Remove(behavior));
+        }
+    }
+
+    public class IgnoreVirtualMembersCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customizations.Add(new IgnoreVirtualMembers());
+        }
+    }
+
+    public class IgnoreVirtualMembers : ISpecimenBuilder
+    {
+        public object? Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var propertyInfo = request as PropertyInfo;
+            if (propertyInfo == null)
+            {
+                return new NoSpecimen();
+            }
+
+            if (propertyInfo.GetMethod != null && propertyInfo.GetMethod.IsVirtual)
+            {
+                return null;
+            }
+
+            return new NoSpecimen();
+        }
+    }
+}

--- a/TsundokuTraducoes/Helpers/RequestHelper.cs
+++ b/TsundokuTraducoes/Helpers/RequestHelper.cs
@@ -77,6 +77,7 @@ namespace TsundokuTraducoes.Api.Helpers
             proxima = proxima != null ? proxima + RetornaQuery(requestObras) : null;
 
             string anterior = RetornaLinkPaginacaoAnterior(itensPorPagina, itensPulados, url);
+            anterior = anterior != null ? anterior + RetornaQuery(requestObras) : null;
 
             return new { total = total, proxima = proxima, anterior = anterior, data = dados };
         }
@@ -116,15 +117,38 @@ namespace TsundokuTraducoes.Api.Helpers
 
         private static string RetornaQuery(RequestObras requestObras)
         {
-            if (!string.IsNullOrEmpty(requestObras.Pesquisar))
-                return $"&Pesquisar={TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.Pesquisar)}";
+            var pesquisar = TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.Pesquisar);
+            if (!string.IsNullOrEmpty(pesquisar))
+                return $"&Pesquisar={pesquisar}";
 
-            return $"&Nacionalidade={TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.Nacionalidade)}" +
-                    $"&Status={TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.Status)}" +
-                    $"&Tipo={TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.Tipo)}" +
-                    $"&Genero={TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.Genero)}" +
-                    $"&IdCapitulo={TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.IdCapitulo)}" +
-                    $"&IdObra={TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.IdObra)}";
+            var nacionalidade = TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.Nacionalidade);
+            var status = TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.Status);
+            var tipo = TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.Tipo);
+            var genero = TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.Genero);
+            var idCapitulo = TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.IdCapitulo);
+            var idObra = TratamentoDeStrings.RetornaStringTratadaSemNull(requestObras.IdObra);
+
+            string queryStringComposta = string.Empty;
+
+            queryStringComposta +=
+                string.IsNullOrEmpty(nacionalidade) ? "" : $"&Nacionalidade={nacionalidade}";
+
+            queryStringComposta +=
+                string.IsNullOrEmpty(status) ? "" : $"&Status={status}";
+
+            queryStringComposta +=
+                string.IsNullOrEmpty(tipo) ? "" : $"&Tipo={tipo}";
+
+            queryStringComposta +=
+                string.IsNullOrEmpty(genero) ? "" : $"&Genero={genero}";
+
+            queryStringComposta +=
+                string.IsNullOrEmpty(idCapitulo) ? "" : $"&IdCapitulo={idCapitulo}";
+
+            queryStringComposta +=
+                string.IsNullOrEmpty(idObra) ? "" : $"&IdObra={idObra}";
+
+            return queryStringComposta;
         }
     }
 }

--- a/TsundokuTraducoes/Helpers/RequestHelper.cs
+++ b/TsundokuTraducoes/Helpers/RequestHelper.cs
@@ -73,7 +73,9 @@ namespace TsundokuTraducoes.Api.Helpers
             var request = httpContext.Request;
             var url = $"{request.Scheme}://{request.Host}{request.Path}";
 
-            string proxima = RetornaLinkPaginacaoProxima(itensPorPagina, itensPulados, dados, url) + RetornaQuery(requestObras);
+            string proxima = RetornaLinkPaginacaoProxima(itensPorPagina, itensPulados, dados, url);
+            proxima = proxima != null ? proxima + RetornaQuery(requestObras) : null;
+
             string anterior = RetornaLinkPaginacaoAnterior(itensPorPagina, itensPulados, url);
 
             return new { total = total, proxima = proxima, anterior = anterior, data = dados };


### PR DESCRIPTION
## Descreva as mudanças feitas nessa PR:
- Adicionados relacionamentos das tabelas GenerosNovel e Genero no retorno das novels;
- Criada a classe ObrasRepositoryFactory para criar os mocks dos objetos;
- Criados testes para verificar se estão retornando uma lista de generos nas novels;
- Adicionada lib AutoFixture para criar mocks dos objetos dinamicamente;
- Criada a classe FixtureCustomization para tratar problema de referência circular ao criar os objetos mockados com a lib AutoFixture;
- Ajustado retorno das obras, na classe RequestHelpers, para não listar parametros desnecessários no retorno das novels

## Ela resolve alguma issue? Informe o número:
[#55](https://github.com/tsundokuapp/tsundoku-api/issues/55)

## Preencha o checklist antes de enviar a PR (delete o que não usar):
- [x] Bug fix (conserta bugs e não causam modificações em outros componentes).
- [x] New feature (adiciona nova funcionalidade).
- [x] Esta PR possui teste inclusos.