### PR TITLE
PR Adição endpoint RetornoCapítuloComic por SlugObra e IdCapitulo

### DIFF
--- a/TsundokuTraducoes.Data/Repositories/CapituloComicRepository.cs
+++ b/TsundokuTraducoes.Data/Repositories/CapituloComicRepository.cs
@@ -21,5 +21,19 @@ namespace TsundokuTraducoes.Data.Repositories
             
             return await query.ToListAsync();
         }
+
+        public async Task<List<CapituloComic>> ObterCapitulosComicPorSlugObra(string slugObra)
+        {
+            var query = from capitulosComic in context.CapitulosComic.AsNoTracking()
+                        join volumesComic in context.VolumesComic.AsNoTracking()
+                          on capitulosComic.VolumeId equals volumesComic.Id
+                        join comics in context.Comics.AsNoTracking()
+                          on volumesComic.ComicId equals comics.Id
+                        where comics.Slug == slugObra
+                        orderby capitulosComic.OrdemCapitulo
+                        select capitulosComic;
+
+            return await query.ToListAsync();
+        }
     }
 }

--- a/TsundokuTraducoes.Domain/Interfaces/Repositories/ICapituloComicRepository.cs
+++ b/TsundokuTraducoes.Domain/Interfaces/Repositories/ICapituloComicRepository.cs
@@ -5,5 +5,6 @@ namespace TsundokuTraducoes.Domain.Interfaces.Repositories
     public interface ICapituloComicRepository
     {
         Task<List<CapituloComic>> ObterCapitulosComicPorIdObra(Guid idObra);
+        Task<List<CapituloComic>> ObterCapitulosComicPorSlugObra(string slugObra);
     }
 }

--- a/TsundokuTraducoes.Domain/Interfaces/Services/ICapituloComicService.cs
+++ b/TsundokuTraducoes.Domain/Interfaces/Services/ICapituloComicService.cs
@@ -5,5 +5,6 @@ namespace TsundokuTraducoes.Domain.Interfaces.Services
     public interface ICapituloComicService
     {
         Task<List<CapituloComic>> ObterCapitulosComicPorIdObra(Guid idObra);
+        Task<List<CapituloComic>> ObterCapitulosComicPorSlugObra(string slugObra);
     }
 }

--- a/TsundokuTraducoes.Domain/Services/CapituloComicService.cs
+++ b/TsundokuTraducoes.Domain/Services/CapituloComicService.cs
@@ -11,5 +11,10 @@ namespace TsundokuTraducoes.Domain.Services
         {
             return await repository.ObterCapitulosComicPorIdObra(idObra);
         }
+
+        public async Task<List<CapituloComic>> ObterCapitulosComicPorSlugObra(string slugObra)
+        {
+            return await repository.ObterCapitulosComicPorSlugObra(slugObra);
+        }
     }
 }

--- a/TsundokuTraducoes.Services/AppServices/CapituloComicAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/CapituloComicAppService.cs
@@ -53,7 +53,7 @@ namespace TsundokuTraducoes.Services.AppServices
             if (resultExisteCapitulo.IsFailed)
                 return Result.Fail(resultExisteCapitulo.Errors[0].Message);
 
-            return Result.Ok();
+            return Result.Ok(listaRetornoCapituloComic);
         }
 
         public Result ValidaExisteCapituloNaLista(List<RetornoCapituloComic> capitulos, Guid idCapitulo)

--- a/TsundokuTraducoes.Services/AppServices/CapituloComicAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/CapituloComicAppService.cs
@@ -34,6 +34,28 @@ namespace TsundokuTraducoes.Services.AppServices
             return Result.Ok(listaRetornoCapituloComic);
         }
 
+        public async Task<Result<List<RetornoCapituloComic>>> ObterCapitulosComicPorSlugObraEIdCapitulo(string slugObra, Guid idCapitulo)
+        {
+            var listaRetornoCapituloComic = new List<RetornoCapituloComic>();
+
+            var obra = obraservice.RetornaComicPorSlug(slugObra);
+            if (obra == null)
+                return Result.Fail("Obra não encontrada!");
+
+            var listaCapituloComic = await service.ObterCapitulosComicPorSlugObra(slugObra);
+
+            foreach (var capituloComic in listaCapituloComic)
+            {
+                listaRetornoCapituloComic.Add(TrataRetornoCapituloComic(capituloComic));
+            }
+
+            var resultExisteCapitulo = ValidaExisteCapituloNaLista(listaRetornoCapituloComic, idCapitulo);
+            if (resultExisteCapitulo.IsFailed)
+                return Result.Fail(resultExisteCapitulo.Errors[0].Message);
+
+            return Result.Ok();
+        }
+
         public Result ValidaExisteCapituloNaLista(List<RetornoCapituloComic> capitulos, Guid idCapitulo)
         {
 
@@ -57,7 +79,5 @@ namespace TsundokuTraducoes.Services.AppServices
 
             return retornoCapitulo;
         }
-
-        
     }
 }

--- a/TsundokuTraducoes.Services/AppServices/Interfaces/ICapituloComicAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/Interfaces/ICapituloComicAppService.cs
@@ -6,6 +6,7 @@ namespace TsundokuTraducoes.Services.AppServices.Interfaces
     public interface ICapituloComicAppService
     {
         Task<Result<List<RetornoCapituloComic>>> ObterCapitulosComicPorIdObraEIdCapitulo(Guid idObra, Guid idCapitulo);
+        Task<Result<List<RetornoCapituloComic>>> ObterCapitulosComicPorSlugObraEIdCapitulo(string slugObra, Guid idCapitulo);
         Result ValidaExisteCapituloNaLista(List<RetornoCapituloComic> capitulos, Guid idCapitulo);
     }
 }

--- a/TsundokuTraducoes.Tests/Services/AppServices/Capitulo/CapituloAppServiceFactoryTestes.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/Capitulo/CapituloAppServiceFactoryTestes.cs
@@ -17,6 +17,11 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             return FixtureCustomizado.RetornaFixtureCustomizado.Build<Comic>().With(x => x.Id, idComic).Create();
         }
 
+        public Comic GerarComic(Guid idComic, string slugObra)
+        {
+            return FixtureCustomizado.RetornaFixtureCustomizado.Build<Comic>().With(x => x.Id, idComic).With(x => x.Slug, slugObra).Create();
+        }
+
         public VolumeComic GerarVolumeComic(Guid idComic)
         {
             return FixtureCustomizado.RetornaFixtureCustomizado.Build<VolumeComic>().With(x => x.ComicId, idComic).Create();
@@ -114,7 +119,7 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             };
 
             return JsonConvert.SerializeObject(lista);
-        }
+        }        
 
         #endregion
     }

--- a/TsundokuTraducoes.Tests/Services/AppServices/Capitulo/CapituloAppServiceTestes.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/Capitulo/CapituloAppServiceTestes.cs
@@ -443,8 +443,7 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
 
             // Assert
             var result = await _capituloComicAppService.ObterCapitulosComicPorIdObraEIdCapitulo(IdObra, listaIdsCapitulos[0]);
-
-            Assert.Equal(slugObra, comic.Slug);
+                        
             Assert.False(result.IsSuccess);
             Assert.Null(result.ValueOrDefault);
             Assert.Contains("Obra não encontrada!", result.Errors[0].Message);

--- a/TsundokuTraducoes.Tests/Services/AppServices/Capitulo/CapituloAppServiceTestes.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/Capitulo/CapituloAppServiceTestes.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using FluentResults;
 using HttpContextMoq;
 using HttpContextMoq.Extensions;
 using Moq;
@@ -240,6 +241,210 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             // Assert
             var result = await _capituloComicAppService.ObterCapitulosComicPorIdObraEIdCapitulo(IdObra, listaIdsCapitulos[0]);
 
+            Assert.False(result.IsSuccess);
+            Assert.Null(result.ValueOrDefault);
+            Assert.Contains("Obra não encontrada!", result.Errors[0].Message);
+        }
+
+
+        [Fact]
+        public void DeveRetornarCapitulo_ComLinksParaProximoEAnterior_NaBuscaPorIdCapituloESlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
+            var capituloAppServiceFactory = new CapituloAppServiceFactoryTestes();
+            Comic comic = capituloAppServiceFactory.GerarComic(IdObra, slugObra);
+            VolumeComic volumeComic = capituloAppServiceFactory.GerarVolumeComic(IdObra);
+            List<CapituloComic> listaCapituloComic = capituloAppServiceFactory.GerarListaCapituloComic(listaIdsCapitulos);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Slug}/{listaIdsCapitulos[1]}";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+            
+            // Assert
+            var retornoListaRetornoCapituloComic = new List<RetornoCapituloComic>();
+
+            listaCapituloComic
+                .ForEach(capituloComic => retornoListaRetornoCapituloComic
+                    .Add(_capituloComicAppService
+                        .TrataRetornoCapituloComic(capituloComic))
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoCapitulosPorSlugComics(httpContext, retornoListaRetornoCapituloComic, listaIdsCapitulos[1]);
+
+            Assert.Equal(slugObra, comic.Slug);
+            Assert.True(objetoRetorno.Data.Id == listaIdsCapitulos[1]);
+            Assert.Contains($"{comic.Slug}/{listaIdsCapitulos[2]}", objetoRetorno.Proxima);
+            Assert.Contains($"{comic.Slug}/{listaIdsCapitulos[0]}", objetoRetorno.Anterior);
+        }
+
+        [Fact]
+        public void DeveRetornarCapitulo_ComLinksParaProximoEAnteriorNull_NaBuscaPorIdCapituloESlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
+            var capituloAppServiceFactory = new CapituloAppServiceFactoryTestes();
+            Comic comic = capituloAppServiceFactory.GerarComic(IdObra, slugObra);
+            VolumeComic volumeComic = capituloAppServiceFactory.GerarVolumeComic(IdObra);
+            List<CapituloComic> listaCapituloComic = capituloAppServiceFactory.GerarListaCapituloComic(listaIdsCapitulos);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Slug}/{listaIdsCapitulos[0]}";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoCapituloComic = new List<RetornoCapituloComic>();
+
+            listaCapituloComic
+                .ForEach(capituloComic => retornoListaRetornoCapituloComic
+                    .Add(_capituloComicAppService
+                        .TrataRetornoCapituloComic(capituloComic))
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoCapitulosPorSlugComics(httpContext, retornoListaRetornoCapituloComic, listaIdsCapitulos[0]);
+
+            Assert.Equal(slugObra, comic.Slug);
+            Assert.True(objetoRetorno.Data.Id == listaIdsCapitulos[0]);
+            Assert.Contains($"{comic.Slug}/{listaIdsCapitulos[1]}", objetoRetorno.Proxima);
+            Assert.Null(objetoRetorno.Anterior);
+        }
+
+        [Fact]
+        public void DeveRetornarCapitulo_ComLinksParaAnteriorEProximoNull_NaBuscaPorIdCapituloESlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
+            var capituloAppServiceFactory = new CapituloAppServiceFactoryTestes();
+            Comic comic = capituloAppServiceFactory.GerarComic(IdObra, slugObra);
+            VolumeComic volumeComic = capituloAppServiceFactory.GerarVolumeComic(IdObra);
+            List<CapituloComic> listaCapituloComic = capituloAppServiceFactory.GerarListaCapituloComic(listaIdsCapitulos);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Slug}/{listaIdsCapitulos[3]}";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoCapituloComic = new List<RetornoCapituloComic>();
+
+            listaCapituloComic
+                .ForEach(capituloComic => retornoListaRetornoCapituloComic
+                    .Add(_capituloComicAppService
+                        .TrataRetornoCapituloComic(capituloComic))
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoCapitulosPorSlugComics(httpContext, retornoListaRetornoCapituloComic, listaIdsCapitulos[3]);
+
+            Assert.Equal(slugObra, comic.Slug);
+            Assert.True(objetoRetorno.Data.Id == listaIdsCapitulos[3]);
+            Assert.Contains($"{comic.Slug}/{listaIdsCapitulos[2]}", objetoRetorno.Anterior);
+            Assert.Null(objetoRetorno.Proxima);
+        }
+
+        [Fact]
+        public void DeveRetornarFalse_QuandoCapituloNaoEncontrado_NaBuscaPorIdCapituloESlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
+            var capituloAppServiceFactory = new CapituloAppServiceFactoryTestes();
+            Comic comic = capituloAppServiceFactory.GerarComic(IdObra, slugObra);
+            VolumeComic volumeComic = capituloAppServiceFactory.GerarVolumeComic(IdObra);
+            List<CapituloComic> listaCapituloComic = capituloAppServiceFactory.GerarListaCapituloComic(listaIdsCapitulos);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Slug}/{listaIdsCapitulos[3]}";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoCapituloComic = new List<RetornoCapituloComic>();
+
+            listaCapituloComic
+                .ForEach(capituloComic => retornoListaRetornoCapituloComic
+                    .Add(_capituloComicAppService
+                        .TrataRetornoCapituloComic(capituloComic))
+                );
+
+            var result = _capituloComicAppService.ValidaExisteCapituloNaLista(retornoListaRetornoCapituloComic, Guid.Parse("1000aaaa-bbbb-cccc-dddd-44444444eeee"));
+
+            Assert.Equal(slugObra, comic.Slug);
+            Assert.False(result.IsSuccess);
+            Assert.Contains("Capítulo não encontrado!", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public async Task DeveRetornarNull_QuandoObraNaoEncontrada_NaBuscaPorIdCapituloESlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
+            var capituloAppServiceFactory = new CapituloAppServiceFactoryTestes();
+            Comic comic = null;
+            VolumeComic volumeComic = capituloAppServiceFactory.GerarVolumeComic(IdObra);
+            List<CapituloComic> listaCapituloComic = capituloAppServiceFactory.GerarListaCapituloComic(listaIdsCapitulos);
+
+            // Mock
+            _ObraServiceMock.Setup(x => x.RetornaComicPorSlug(slugObra)).Returns(comic);
+
+            // Assert
+            var result = await _capituloComicAppService.ObterCapitulosComicPorIdObraEIdCapitulo(IdObra, listaIdsCapitulos[0]);
+
+            Assert.Equal(slugObra, comic.Slug);
             Assert.False(result.IsSuccess);
             Assert.Null(result.ValueOrDefault);
             Assert.Contains("Obra não encontrada!", result.Errors[0].Message);

--- a/TsundokuTraducoes/Controllers/Publico/comic/CapitulosComicsController.cs
+++ b/TsundokuTraducoes/Controllers/Publico/comic/CapitulosComicsController.cs
@@ -20,5 +20,16 @@ namespace TsundokuTraducoes.Api.Controllers.Publico.manga
             var objetoRetorno = RequestHelper.CriarObjetoRetonoCapitulosComics(HttpContext, result.Value, idCapitulo);
             return Ok(objetoRetorno);
         }
+
+        [HttpGet("api/comics/{slugObra}/{idCapitulo}")]
+        public async Task<IActionResult> ObterCapitulosComicPorSlugObraEIdCapitulo(string slugObra, Guid idCapitulo)
+        {
+            var result = await service.ObterCapitulosComicPorSlugObraEIdCapitulo(slugObra, idCapitulo);
+            if (result.IsFailed)
+                return NotFound(result.Errors[0].Message);
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoCapitulosComics(HttpContext, result.Value, idCapitulo);
+            return Ok(objetoRetorno);
+        }
     }
 }

--- a/TsundokuTraducoes/Controllers/Publico/comic/CapitulosComicsController.cs
+++ b/TsundokuTraducoes/Controllers/Publico/comic/CapitulosComicsController.cs
@@ -21,14 +21,14 @@ namespace TsundokuTraducoes.Api.Controllers.Publico.manga
             return Ok(objetoRetorno);
         }
 
-        [HttpGet("api/comics/{slugObra}/{idCapitulo}")]
+        [HttpGet("api/comics/slug/{slugObra}/{idCapitulo}")]
         public async Task<IActionResult> ObterCapitulosComicPorSlugObraEIdCapitulo(string slugObra, Guid idCapitulo)
         {
             var result = await service.ObterCapitulosComicPorSlugObraEIdCapitulo(slugObra, idCapitulo);
             if (result.IsFailed)
                 return NotFound(result.Errors[0].Message);
 
-            var objetoRetorno = RequestHelper.CriarObjetoRetonoCapitulosComics(HttpContext, result.Value, idCapitulo);
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoCapitulosPorSlugComics(HttpContext, result.Value, idCapitulo);
             return Ok(objetoRetorno);
         }
     }

--- a/TsundokuTraducoes/Helpers/RequestHelper.cs
+++ b/TsundokuTraducoes/Helpers/RequestHelper.cs
@@ -123,6 +123,33 @@ namespace TsundokuTraducoes.Api.Helpers
             return new ObjetoRetornoCapituloComicResponse { Anterior = anterior , Proxima = proxima, Data = retornoCapituloComic };
         }
 
+        public static ObjetoRetornoCapituloComicResponse CriarObjetoRetonoCapitulosPorSlugComics(HttpContext httpContext, List<RetornoCapituloComic> listaRetornoCapituloComic, Guid idCapitulo)
+        {
+            var retornoCapituloComic = listaRetornoCapituloComic.FirstOrDefault(x => x.Id == idCapitulo);
+
+            var indiceCapitulo = listaRetornoCapituloComic
+                .IndexOf(retornoCapituloComic);
+
+            var request = httpContext.Request;
+            string anterior = null;
+            if (indiceCapitulo > 0)
+            {
+                var idAnterior = listaRetornoCapituloComic[indiceCapitulo - 1].Id;
+                var urlSemSlugAtual = request.Path.Value.Substring(0, request.Path.Value.LastIndexOf("/"));
+                anterior = $"{request.Scheme}://{request.Host}{urlSemSlugAtual}/{idAnterior}";
+            }
+
+            string proxima = null;
+            if (indiceCapitulo + 1 < listaRetornoCapituloComic.Count)
+            {
+                var idProximo = listaRetornoCapituloComic[indiceCapitulo + 1].Id;
+                var urlSemSlugAtual = request.Path.Value.Substring(0, request.Path.Value.LastIndexOf("/"));
+                proxima = $"{request.Scheme}://{request.Host}{urlSemSlugAtual}/{idProximo}";
+            }
+
+            return new ObjetoRetornoCapituloComicResponse { Anterior = anterior, Proxima = proxima, Data = retornoCapituloComic };
+        }
+
         public static ObjetoRetornoCapituloNovelResponse CriarObjetoRetonoCapitulosNovel(HttpContext httpContext, List<RetornoCapituloNovel> listaRetornoCapituloNovel, Guid idCapitulo)
         {
             var retornoCapituloNovel = listaRetornoCapituloNovel.FirstOrDefault(x => x.Id == idCapitulo);


### PR DESCRIPTION
## Descreva as mudanças feitas nessa PR:
- Adicionado méto **_ObterCapitulosComicPorSlugObra_** nas classes:
  - CapituloComicRepository.cs 
  - ICapituloComicRepository.cs
  - CapituloComicService.cs 
  - ICapituloComicService.cs 
  - CapituloComicAppService.cs
  - ICapituloComicAppService.cs
   
- Adicionados métodos de testes nas classes:
  - CapituloAppServiceFactoryTestes.cs
  - CapituloAppServiceTestes.cs

- Adicionado método **_ObterCapitulosComicPorSlugObraEIdCapitulo_** na classe:
  -  CapitulosComicsController.cs

- Adicionado método **_CriarObjetoRetonoCapitulosPorSlugComics_** na classe:
  - RequestHelper.cs
  
- Rota adicionada:
  - `"api/comics/slug/{slugObra}/{idCapitulo}"`

## Ela resolve alguma issue? Informe o número:
[#63](https://github.com/tsundokuapp/tsundoku-api/issues/63)

## Preencha o checklist antes de enviar a PR (delete o que não usar):
- [x] New feature (adiciona nova funcionalidade).
- [x] Esta PR possui teste inclusos.