### PR TITLE
PR com adição de endpoint publico para retorno volumes de Comics

### DIFF
--- a/TsundokuTraducoes.Data/Migrations/20250326030309_AdicionadoCamposPublicoOrdemVolumeParaVolumes.Designer.cs
+++ b/TsundokuTraducoes.Data/Migrations/20250326030309_AdicionadoCamposPublicoOrdemVolumeParaVolumes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TsundokuTraducoes.Data.Context;
 
@@ -11,9 +12,11 @@ using TsundokuTraducoes.Data.Context;
 namespace TsundokuTraducoes.Data.Migrations
 {
     [DbContext(typeof(ContextBase))]
-    partial class ContextBaseModelSnapshot : ModelSnapshot
+    [Migration("20250326030309_AdicionadoCamposPublicoOrdemVolumeParaVolumes")]
+    partial class AdicionadoCamposPublicoOrdemVolumeParaVolumes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TsundokuTraducoes.Data/Migrations/20250326030309_AdicionadoCamposPublicoOrdemVolumeParaVolumes.cs
+++ b/TsundokuTraducoes.Data/Migrations/20250326030309_AdicionadoCamposPublicoOrdemVolumeParaVolumes.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace TsundokuTraducoes.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdicionadoCamposPublicoOrdemVolumeParaVolumes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("28330e22-bd1c-489b-ace7-7e55e9b9573b"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("773e1482-4765-41ce-9b0b-8441de1677a0"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("8a371dfa-2ca0-48ae-bb97-82213ae463ef"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("9b566314-f13c-42a6-a40c-ee11752424e3"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("bbbbd7c3-0e04-4540-b039-0aa94f3d5ac6"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("c501e19d-2f50-4e98-a8f1-54d9dd145474"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("dda695de-b958-4009-84e8-987863d3046a"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("f516c212-8bd7-4755-86f0-dfd45ade654f"));
+
+            migrationBuilder.AddColumn<int>(
+                name: "OrdemVolume",
+                table: "VolumesNovel",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Publicado",
+                table: "VolumesNovel",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OrdemVolume",
+                table: "VolumesComic",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Publicado",
+                table: "VolumesComic",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.UpdateData(
+                table: "CapitulosComic",
+                keyColumn: "Id",
+                keyValue: new Guid("08dba6c0-f903-469b-866c-223f5ab45e56"),
+                columns: new[] { "DataAlteracao", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 3, 26, 0, 3, 7, 967, DateTimeKind.Local).AddTicks(83), new DateTime(2025, 3, 26, 0, 3, 7, 967, DateTimeKind.Local).AddTicks(82) });
+
+            migrationBuilder.UpdateData(
+                table: "CapitulosNovel",
+                keyColumn: "Id",
+                keyValue: new Guid("08dba6b4-3619-4cc6-8857-0bbe53a6f670"),
+                columns: new[] { "DataAlteracao", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9352), new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9352) });
+
+            migrationBuilder.UpdateData(
+                table: "CapitulosNovel",
+                keyColumn: "Id",
+                keyValue: new Guid("08dba6bb-8faf-4ce3-85d7-7cfe5b59648b"),
+                columns: new[] { "DataAlteracao", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9668), new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9667) });
+
+            migrationBuilder.UpdateData(
+                table: "Comics",
+                keyColumn: "Id",
+                keyValue: new Guid("3d6a759d-8c9e-4891-9f0e-89b8d99821cb"),
+                columns: new[] { "DataAlteracao", "DataAtualizacaoUltimoCapitulo", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9019), new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9152), new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9019) });
+
+            migrationBuilder.InsertData(
+                table: "Generos",
+                columns: new[] { "Id", "DataAlteracao", "DataInclusao", "Descricao", "Slug", "UsuarioAlteracao", "UsuarioInclusao" },
+                values: new object[,]
+                {
+                    { new Guid("063216e7-fdc5-45f6-b497-f325ecff98e0"), null, null, "Ação", "acao", null, null },
+                    { new Guid("2315bb4f-929c-47d4-9712-873a168fbb55"), null, null, "Fantasia", "fantasia", null, null },
+                    { new Guid("2b273d16-ebbe-4bbc-b6df-0d69fbab68c3"), null, null, "Slice of Life", "slice-of-life", null, null },
+                    { new Guid("3d208749-03ef-4dd5-81a9-fde7e1c16db1"), null, null, "Horror", "horror", null, null },
+                    { new Guid("4f19e568-b1a5-460e-b560-e5839dabc128"), null, null, "Comédia", "comedia", null, null },
+                    { new Guid("650236f4-34da-4dc4-8303-6fb55867004a"), null, null, "Drama", "drama", null, null },
+                    { new Guid("74b81ceb-6207-4d9f-a878-859e954bc09e"), null, null, "Harém", "harem", null, null },
+                    { new Guid("bb28228b-caae-4ef0-a5a5-aab244fa426a"), null, null, "Isekai", "isekai", null, null }
+                });
+
+            migrationBuilder.UpdateData(
+                table: "Novels",
+                keyColumn: "Id",
+                keyValue: new Guid("97722a6d-2210-434b-ae48-1a3c6da4c7a8"),
+                columns: new[] { "DataAlteracao", "DataAtualizacaoUltimoCapitulo", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(8817), new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(8990), new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(8813) });
+
+            migrationBuilder.UpdateData(
+                table: "VolumesComic",
+                keyColumn: "Id",
+                keyValue: new Guid("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                columns: new[] { "DataAlteracao", "DataInclusao", "OrdemVolume", "Publicado" },
+                values: new object[] { new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9270), new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9270), 0, false });
+
+            migrationBuilder.UpdateData(
+                table: "VolumesNovel",
+                keyColumn: "Id",
+                keyValue: new Guid("08dba651-c8ee-460a-8b4a-56573c446d2a"),
+                columns: new[] { "DataAlteracao", "DataInclusao", "OrdemVolume", "Publicado" },
+                values: new object[] { new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9180), new DateTime(2025, 3, 26, 0, 3, 7, 966, DateTimeKind.Local).AddTicks(9180), 0, false });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("063216e7-fdc5-45f6-b497-f325ecff98e0"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("2315bb4f-929c-47d4-9712-873a168fbb55"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("2b273d16-ebbe-4bbc-b6df-0d69fbab68c3"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("3d208749-03ef-4dd5-81a9-fde7e1c16db1"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("4f19e568-b1a5-460e-b560-e5839dabc128"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("650236f4-34da-4dc4-8303-6fb55867004a"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("74b81ceb-6207-4d9f-a878-859e954bc09e"));
+
+            migrationBuilder.DeleteData(
+                table: "Generos",
+                keyColumn: "Id",
+                keyValue: new Guid("bb28228b-caae-4ef0-a5a5-aab244fa426a"));
+
+            migrationBuilder.DropColumn(
+                name: "OrdemVolume",
+                table: "VolumesNovel");
+
+            migrationBuilder.DropColumn(
+                name: "Publicado",
+                table: "VolumesNovel");
+
+            migrationBuilder.DropColumn(
+                name: "OrdemVolume",
+                table: "VolumesComic");
+
+            migrationBuilder.DropColumn(
+                name: "Publicado",
+                table: "VolumesComic");
+
+            migrationBuilder.UpdateData(
+                table: "CapitulosComic",
+                keyColumn: "Id",
+                keyValue: new Guid("08dba6c0-f903-469b-866c-223f5ab45e56"),
+                columns: new[] { "DataAlteracao", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(6421), new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(6421) });
+
+            migrationBuilder.UpdateData(
+                table: "CapitulosNovel",
+                keyColumn: "Id",
+                keyValue: new Guid("08dba6b4-3619-4cc6-8857-0bbe53a6f670"),
+                columns: new[] { "DataAlteracao", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5709), new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5709) });
+
+            migrationBuilder.UpdateData(
+                table: "CapitulosNovel",
+                keyColumn: "Id",
+                keyValue: new Guid("08dba6bb-8faf-4ce3-85d7-7cfe5b59648b"),
+                columns: new[] { "DataAlteracao", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(6056), new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(6055) });
+
+            migrationBuilder.UpdateData(
+                table: "Comics",
+                keyColumn: "Id",
+                keyValue: new Guid("3d6a759d-8c9e-4891-9f0e-89b8d99821cb"),
+                columns: new[] { "DataAlteracao", "DataAtualizacaoUltimoCapitulo", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5430), new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5511), new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5429) });
+
+            migrationBuilder.InsertData(
+                table: "Generos",
+                columns: new[] { "Id", "DataAlteracao", "DataInclusao", "Descricao", "Slug", "UsuarioAlteracao", "UsuarioInclusao" },
+                values: new object[,]
+                {
+                    { new Guid("28330e22-bd1c-489b-ace7-7e55e9b9573b"), null, null, "Isekai", "isekai", null, null },
+                    { new Guid("773e1482-4765-41ce-9b0b-8441de1677a0"), null, null, "Harém", "harem", null, null },
+                    { new Guid("8a371dfa-2ca0-48ae-bb97-82213ae463ef"), null, null, "Comédia", "comedia", null, null },
+                    { new Guid("9b566314-f13c-42a6-a40c-ee11752424e3"), null, null, "Horror", "horror", null, null },
+                    { new Guid("bbbbd7c3-0e04-4540-b039-0aa94f3d5ac6"), null, null, "Drama", "drama", null, null },
+                    { new Guid("c501e19d-2f50-4e98-a8f1-54d9dd145474"), null, null, "Ação", "acao", null, null },
+                    { new Guid("dda695de-b958-4009-84e8-987863d3046a"), null, null, "Slice of Life", "slice-of-life", null, null },
+                    { new Guid("f516c212-8bd7-4755-86f0-dfd45ade654f"), null, null, "Fantasia", "fantasia", null, null }
+                });
+
+            migrationBuilder.UpdateData(
+                table: "Novels",
+                keyColumn: "Id",
+                keyValue: new Guid("97722a6d-2210-434b-ae48-1a3c6da4c7a8"),
+                columns: new[] { "DataAlteracao", "DataAtualizacaoUltimoCapitulo", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5156), new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5396), new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5148) });
+
+            migrationBuilder.UpdateData(
+                table: "VolumesComic",
+                keyColumn: "Id",
+                keyValue: new Guid("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                columns: new[] { "DataAlteracao", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5627), new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5626) });
+
+            migrationBuilder.UpdateData(
+                table: "VolumesNovel",
+                keyColumn: "Id",
+                keyValue: new Guid("08dba651-c8ee-460a-8b4a-56573c446d2a"),
+                columns: new[] { "DataAlteracao", "DataInclusao" },
+                values: new object[] { new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5540), new DateTime(2025, 2, 14, 6, 56, 0, 726, DateTimeKind.Local).AddTicks(5539) });
+        }
+    }
+}

--- a/TsundokuTraducoes.Data/Repositories/VolumeComicRepository.cs
+++ b/TsundokuTraducoes.Data/Repositories/VolumeComicRepository.cs
@@ -9,26 +9,26 @@ namespace TsundokuTraducoes.Data.Repositories
     {
         public async Task<List<VolumeComic>> ObterVolumesComicPorIdObra(Guid idObra)
         {
-            var query = from volumesComic in context.VolumesComic.AsNoTracking()                          
-                        join comics in context.Comics.AsNoTracking()
-                          on volumesComic.ComicId equals comics.Id
-                        where comics.Id == idObra
-                        orderby volumesComic.Numero
-                        select volumesComic;
+            var listaVolumes = await context.VolumesComic
+                .AsNoTracking()
+                .Include(x => x.ListaCapitulo)
+                .Where(x => x.ComicId == idObra)
+                .OrderBy(x => x.OrdemVolume)
+                .ToListAsync();
 
-            return await query.ToListAsync();
+            return listaVolumes;
         }
 
         public async Task<List<VolumeComic>> ObterVolumesComicPorSlugObra(string slugObra)
         {
-            var query = from volumesComic in context.VolumesComic.AsNoTracking()
-                        join comics in context.Comics.AsNoTracking()
-                          on volumesComic.ComicId equals comics.Id
-                        where comics.Slug == slugObra
-                        orderby volumesComic.Numero
-                        select volumesComic;
+            var listaVolumes = await context.VolumesComic
+                .AsNoTracking()
+                .Include(x => x.ListaCapitulo)
+                .Where(x => x.Comic.Slug == slugObra)
+                .OrderBy(x => x.OrdemVolume)
+                .ToListAsync();
 
-            return await query.ToListAsync();
+            return listaVolumes;
         }
     }
 }

--- a/TsundokuTraducoes.Data/Repositories/VolumeComicRepository.cs
+++ b/TsundokuTraducoes.Data/Repositories/VolumeComicRepository.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TsundokuTraducoes.Data.Context;
+using TsundokuTraducoes.Domain.Interfaces.Repositories;
+using TsundokuTraducoes.Entities.Entities.Volume;
+
+namespace TsundokuTraducoes.Data.Repositories
+{
+    public class VolumeComicRepository(ContextBase context) : IVolumeComicRepository
+    {
+        public async Task<List<VolumeComic>> ObterVolumesComicPorIdObra(Guid idObra)
+        {
+            var query = from volumesComic in context.VolumesComic.AsNoTracking()                          
+                        join comics in context.Comics.AsNoTracking()
+                          on volumesComic.ComicId equals comics.Id
+                        where comics.Id == idObra
+                        orderby volumesComic.Numero
+                        select volumesComic;
+
+            return await query.ToListAsync();
+        }
+
+        public async Task<List<VolumeComic>> ObterVolumesComicPorSlugObra(string slugObra)
+        {
+            var query = from volumesComic in context.VolumesComic.AsNoTracking()
+                        join comics in context.Comics.AsNoTracking()
+                          on volumesComic.ComicId equals comics.Id
+                        where comics.Slug == slugObra
+                        orderby volumesComic.Numero
+                        select volumesComic;
+
+            return await query.ToListAsync();
+        }
+    }
+}

--- a/TsundokuTraducoes.Domain/Interfaces/Repositories/IVolumeComicRepository.cs
+++ b/TsundokuTraducoes.Domain/Interfaces/Repositories/IVolumeComicRepository.cs
@@ -1,0 +1,10 @@
+﻿using TsundokuTraducoes.Entities.Entities.Volume;
+
+namespace TsundokuTraducoes.Domain.Interfaces.Repositories
+{
+    public interface IVolumeComicRepository
+    {
+        Task<List<VolumeComic>> ObterVolumesComicPorIdObra(Guid idObra);
+        Task<List<VolumeComic>> ObterVolumesComicPorSlugObra(string slugObra);
+    }
+}

--- a/TsundokuTraducoes.Domain/Interfaces/Services/IVolumeComicService.cs
+++ b/TsundokuTraducoes.Domain/Interfaces/Services/IVolumeComicService.cs
@@ -1,0 +1,10 @@
+﻿using TsundokuTraducoes.Entities.Entities.Volume;
+
+namespace TsundokuTraducoes.Domain.Interfaces.Services
+{
+    public interface IVolumeComicService
+    {
+        Task<List<VolumeComic>> ObterVolumesComicPorIdObra(Guid idObra);
+        Task<List<VolumeComic>> ObterVolumesComicPorSlugObra(string slugObra);
+    }
+}

--- a/TsundokuTraducoes.Domain/Services/VolumeComicService.cs
+++ b/TsundokuTraducoes.Domain/Services/VolumeComicService.cs
@@ -1,0 +1,20 @@
+﻿using TsundokuTraducoes.Domain.Interfaces.Repositories;
+using TsundokuTraducoes.Domain.Interfaces.Services;
+using TsundokuTraducoes.Entities.Entities.Volume;
+using TsundokuTraducoes.Helpers.Services.Interfaces;
+
+namespace TsundokuTraducoes.Domain.Services
+{
+    public class VolumeComicService(IVolumeComicRepository repository) : IVolumeComicService, IBaseService<IVolumeComicRepository>
+    {
+        public async Task<List<VolumeComic>> ObterVolumesComicPorIdObra(Guid idObra)
+        {
+            return await repository.ObterVolumesComicPorIdObra(idObra);
+        }
+
+        public async Task<List<VolumeComic>> ObterVolumesComicPorSlugObra(string slugObra)
+        {
+            return await repository.ObterVolumesComicPorSlugObra(slugObra);
+        }
+    }
+}

--- a/TsundokuTraducoes.Entities/Entities/Volume/VolumeComic.cs
+++ b/TsundokuTraducoes.Entities/Entities/Volume/VolumeComic.cs
@@ -22,6 +22,8 @@ namespace TsundokuTraducoes.Entities.Entities.Volume
         public Guid ComicId { get; set; }
         public virtual Comic Comic { get; set; }
         public List<CapituloComic> ListaCapitulo { get; set; }
+        public int OrdemVolume { get; set; }
+        public bool Publicado { get; set; }
 
         public VolumeComic()
         {

--- a/TsundokuTraducoes.Entities/Entities/Volume/VolumeNovel.cs
+++ b/TsundokuTraducoes.Entities/Entities/Volume/VolumeNovel.cs
@@ -22,7 +22,9 @@ namespace TsundokuTraducoes.Entities.Entities.Volume
         public Guid NovelId { get; set; }
         public virtual Novel Novel { get; set; }
         public List<CapituloNovel> ListaCapitulo { get; set; }
-                
+        public int OrdemVolume { get; set; }
+        public bool Publicado { get; set; }
+
         public VolumeNovel()
         {            
             ListaCapitulo = new List<CapituloNovel>();

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/Response/ObjetoRetornoVolumeComicResponse.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/Response/ObjetoRetornoVolumeComicResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace TsundokuTraducoes.Helpers.DTOs.Public.Retorno.Response
+{
+    public class ObjetoRetornoVolumeComicResponse
+    {
+        public string Proxima { get; set; }
+        public string Anterior { get; set; }
+        public List<RetornoVolumeComic> Data { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoCapituloComic.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoCapituloComic.cs
@@ -14,6 +14,7 @@ namespace TsundokuTraducoes.Helpers.DTOs.Public.Retorno
         public string DataAlteracao { get; set; }
         public int OrdemCapitulo { get; set; }
         public string DescritivoCapitulo => TratamentoDeStrings.RetornaDescritivoCapitulo(Numero, Parte);
-        public List<EnderecoImagemDTO> ListaImagens { get; set; }
+        public bool Publicado { get; set; }
+        public List<EnderecoImagemDTO> ListaImagens { get; set; }        
     }
 }

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoVolumeComic.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoVolumeComic.cs
@@ -8,5 +8,9 @@
         public string UrlCapaVolume { get; set; }
         public string SlugVolume { get; set; }
         public string Sinopse { get; set; }
+        public int OrdemVolume { get; set; }
+        public bool Publicado { get; set; }
+        public string Titulo { get; set; }
+        public List<RetornoCapituloComic> ListaRetornoCapitulosComic { get; set; }
     }
 }

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoVolumeComic.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoVolumeComic.cs
@@ -1,0 +1,12 @@
+﻿namespace TsundokuTraducoes.Helpers.DTOs.Public.Retorno
+{
+    public class RetornoVolumeComic
+    {
+        public Guid IdObra { get; set; }
+        public Guid Id { get; set; }
+        public string NumeroVolume { get; set; }
+        public string UrlCapaVolume { get; set; }
+        public string SlugVolume { get; set; }
+        public string Sinopse { get; set; }
+    }
+}

--- a/TsundokuTraducoes.Services/AppServices/Interfaces/IVolumeComicAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/Interfaces/IVolumeComicAppService.cs
@@ -1,0 +1,11 @@
+﻿using FluentResults;
+using TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
+
+namespace TsundokuTraducoes.Services.AppServices.Interfaces
+{
+    public interface IVolumeComicAppService
+    {
+        Task<Result<List<RetornoVolumeComic>>> ObterVolumesComicPorIdObra(Guid idObra);
+        Task<Result<List<RetornoVolumeComic>>> ObterVolumesComicPorSlugObra(string slugObra);
+    }
+}

--- a/TsundokuTraducoes.Services/AppServices/VolumeComicAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/VolumeComicAppService.cs
@@ -1,14 +1,18 @@
-﻿using FluentResults;
+﻿using AutoMapper;
+using FluentResults;
+using Newtonsoft.Json;
 using TsundokuTraducoes.Domain.Interfaces.Services;
+using TsundokuTraducoes.Entities.Entities.Capitulo;
 using TsundokuTraducoes.Entities.Entities.Volume;
+using TsundokuTraducoes.Helpers.DTOs.Admin;
 using TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
 using TsundokuTraducoes.Helpers.Services.Interfaces;
 using TsundokuTraducoes.Services.AppServices.Interfaces;
 
 namespace TsundokuTraducoes.Services.AppServices
 {
-    public class VolumeComicAppService(IVolumeComicService service, IObraService obraservice) 
-        : IVolumeComicAppService, IBaseService<IVolumeComicService, IObraService>
+    public class VolumeComicAppService(IVolumeComicService service, IObraService obraservice, IMapper mapper) 
+        : IVolumeComicAppService, IBaseService<IVolumeComicService, IObraService, IMapper>
     {
         public async Task<Result<List<RetornoVolumeComic>>> ObterVolumesComicPorIdObra(Guid idObra)
         {
@@ -63,7 +67,11 @@ namespace TsundokuTraducoes.Services.AppServices
                 NumeroVolume = volumeComic.Numero,
                 Sinopse = volumeComic.Sinopse,
                 SlugVolume = volumeComic.Slug,
-                UrlCapaVolume = volumeComic.ImagemVolume
+                UrlCapaVolume = volumeComic.ImagemVolume,
+                OrdemVolume = volumeComic.OrdemVolume,
+                Publicado = volumeComic.Publicado,
+                Titulo = volumeComic.Titulo,
+                ListaRetornoCapitulosComic = TrataListaRetornoCapituloComic(volumeComic.ListaCapitulo)
             };
         }
 
@@ -71,8 +79,29 @@ namespace TsundokuTraducoes.Services.AppServices
         {
             if (listaVolumeComic.Count == 0)
                 return Result.Fail("Lista de volumes não encontrado para essa obra!");
-
             return Result.Ok();
+        }
+
+        public List<RetornoCapituloComic> TrataListaRetornoCapituloComic(List<CapituloComic> listaCapituloComic)
+        {
+            var listaRetornoCapituloComic = new List<RetornoCapituloComic>();
+
+            foreach (var capituloComic in listaCapituloComic.OrderBy(x => x.OrdemCapitulo))
+            {
+                var retornoCapitulo = mapper.Map<RetornoCapituloComic>(capituloComic);
+                retornoCapitulo.DataInclusao = capituloComic.DataInclusao.ToString("dd/MM/yyyy HH:mm:ss");
+                retornoCapitulo.DataAlteracao = capituloComic.DataAlteracao.ToString("dd/MM/yyyy HH:mm:ss");
+                retornoCapitulo.UsuarioAlteracao = !string.IsNullOrEmpty(capituloComic.UsuarioAlteracao) ? capituloComic.UsuarioAlteracao : null;
+
+                if (!string.IsNullOrEmpty(capituloComic.ListaImagensJson))
+                {
+                    retornoCapitulo.ListaImagens = JsonConvert.DeserializeObject<List<EnderecoImagemDTO>>(capituloComic.ListaImagensJson);
+                }
+
+                listaRetornoCapituloComic.Add(retornoCapitulo);
+            }
+
+            return listaRetornoCapituloComic;
         }
     }
 }

--- a/TsundokuTraducoes.Services/AppServices/VolumeComicAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/VolumeComicAppService.cs
@@ -1,0 +1,60 @@
+﻿using FluentResults;
+using TsundokuTraducoes.Domain.Interfaces.Services;
+using TsundokuTraducoes.Entities.Entities.Volume;
+using TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
+using TsundokuTraducoes.Helpers.Services.Interfaces;
+using TsundokuTraducoes.Services.AppServices.Interfaces;
+
+namespace TsundokuTraducoes.Services.AppServices
+{
+    public class VolumeComicAppService(IVolumeComicService service, IObraService obraservice) 
+        : IVolumeComicAppService, IBaseService<IVolumeComicService, IObraService>
+    {
+        public async Task<Result<List<RetornoVolumeComic>>> ObterVolumesComicPorIdObra(Guid idObra)
+        {
+            var obra = obraservice.RetornaComicPorId(idObra);
+            if (obra == null)
+                return Result.Fail("Obra não encontrada!");
+
+            var listaRetornoVolumeComic = new List<RetornoVolumeComic>();
+            var listaVolumeComic = await service.ObterVolumesComicPorIdObra(idObra);
+
+            foreach (var volumeComic in listaVolumeComic)
+            {
+                listaRetornoVolumeComic.Add(TrataRetornoVolumeComic(volumeComic));
+            }
+
+            return Result.Ok(listaRetornoVolumeComic);
+        }
+
+        public async Task<Result<List<RetornoVolumeComic>>> ObterVolumesComicPorSlugObra(string slugObra)
+        {
+            var obra = obraservice.RetornaComicPorSlug(slugObra);
+            if (obra == null)
+                return Result.Fail("Obra não encontrada!");
+
+            var listaRetornoVolumeComic = new List<RetornoVolumeComic>();
+            var listaVolumeComic = await service.ObterVolumesComicPorSlugObra(slugObra);
+
+            foreach (var volumeComic in listaVolumeComic)
+            {
+                listaRetornoVolumeComic.Add(TrataRetornoVolumeComic(volumeComic));
+            }
+
+            return Result.Ok(listaRetornoVolumeComic);
+        }
+
+        public static RetornoVolumeComic TrataRetornoVolumeComic(VolumeComic volumeComic)
+        {
+            return new RetornoVolumeComic
+            {
+                Id = volumeComic.Id,
+                IdObra = volumeComic.ComicId,
+                NumeroVolume = volumeComic.Numero,
+                Sinopse = volumeComic.Sinopse,
+                SlugVolume = volumeComic.Slug,
+                UrlCapaVolume = volumeComic.ImagemVolume
+            };
+        }
+    }
+}

--- a/TsundokuTraducoes.Services/AppServices/VolumeComicAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/VolumeComicAppService.cs
@@ -16,8 +16,13 @@ namespace TsundokuTraducoes.Services.AppServices
             if (obra == null)
                 return Result.Fail("Obra não encontrada!");
 
-            var listaRetornoVolumeComic = new List<RetornoVolumeComic>();
             var listaVolumeComic = await service.ObterVolumesComicPorIdObra(idObra);
+
+            var resultExisteListaVolume = ValidaExisteListaVolume(listaVolumeComic);
+            if (resultExisteListaVolume.IsFailed)
+                return Result.Fail(resultExisteListaVolume.Errors[0].Message);
+
+            var listaRetornoVolumeComic = new List<RetornoVolumeComic>();
 
             foreach (var volumeComic in listaVolumeComic)
             {
@@ -33,9 +38,14 @@ namespace TsundokuTraducoes.Services.AppServices
             if (obra == null)
                 return Result.Fail("Obra não encontrada!");
 
-            var listaRetornoVolumeComic = new List<RetornoVolumeComic>();
             var listaVolumeComic = await service.ObterVolumesComicPorSlugObra(slugObra);
 
+            var resultExisteListaVolume = ValidaExisteListaVolume(listaVolumeComic);
+            if (resultExisteListaVolume.IsFailed)
+                return Result.Fail(resultExisteListaVolume.Errors[0].Message);
+
+            var listaRetornoVolumeComic = new List<RetornoVolumeComic>();
+            
             foreach (var volumeComic in listaVolumeComic)
             {
                 listaRetornoVolumeComic.Add(TrataRetornoVolumeComic(volumeComic));
@@ -44,7 +54,7 @@ namespace TsundokuTraducoes.Services.AppServices
             return Result.Ok(listaRetornoVolumeComic);
         }
 
-        public static RetornoVolumeComic TrataRetornoVolumeComic(VolumeComic volumeComic)
+        public RetornoVolumeComic TrataRetornoVolumeComic(VolumeComic volumeComic)
         {
             return new RetornoVolumeComic
             {
@@ -55,6 +65,14 @@ namespace TsundokuTraducoes.Services.AppServices
                 SlugVolume = volumeComic.Slug,
                 UrlCapaVolume = volumeComic.ImagemVolume
             };
+        }
+
+        public Result ValidaExisteListaVolume(List<VolumeComic> listaVolumeComic)
+        {
+            if (listaVolumeComic.Count == 0)
+                return Result.Fail("Lista de volumes não encontrado para essa obra!");
+
+            return Result.Ok();
         }
     }
 }

--- a/TsundokuTraducoes.Services/Profiles/VolumeProfile.cs
+++ b/TsundokuTraducoes.Services/Profiles/VolumeProfile.cs
@@ -2,6 +2,7 @@
 using TsundokuTraducoes.Entities.Entities.Volume;
 using TsundokuTraducoes.Helpers.DTOs.Admin;
 using TsundokuTraducoes.Helpers.DTOs.Admin.Retorno;
+using TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
 
 namespace TsundokuTraducoes.Services.Profiles
 {
@@ -13,6 +14,7 @@ namespace TsundokuTraducoes.Services.Profiles
             CreateMap<VolumeDTO, VolumeComic>();
             CreateMap<VolumeNovel, RetornoVolume>();
             CreateMap<VolumeComic, RetornoVolume>();
+            CreateMap<VolumeComic, RetornoVolumeComic>();
         }
     }
 }

--- a/TsundokuTraducoes.Tests/Entities/Volumes/VolumesTestes.cs
+++ b/TsundokuTraducoes.Tests/Entities/Volumes/VolumesTestes.cs
@@ -72,7 +72,7 @@ namespace TsundokuTraducoes.Tests.Entities.Volumes
             Assert.NotEqual(new DateTime(), volumeNovel.DataAlteracao);
             Assert.False(string.IsNullOrEmpty(volumeNovel.DiretorioImagemVolume));
             Assert.False(volumeNovel.ListaCapitulo.Any());
-            Assert.Equal(14, numeroDeCamposDoVolumeNovel);
+            Assert.Equal(16, numeroDeCamposDoVolumeNovel);
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace TsundokuTraducoes.Tests.Entities.Volumes
             Assert.NotEqual(new DateTime(), volumeNovel.DataAlteracao);
             Assert.False(string.IsNullOrEmpty(volumeNovel.DiretorioImagemVolume));
             Assert.False(volumeNovel.ListaCapitulo.Any());
-            Assert.Equal(14, numeroDeCamposDoVolumeNovel);
+            Assert.Equal(16, numeroDeCamposDoVolumeNovel);
 
         }
 
@@ -121,7 +121,7 @@ namespace TsundokuTraducoes.Tests.Entities.Volumes
             Assert.NotEqual(new DateTime(), volumeNovel.DataAlteracao);
             Assert.False(string.IsNullOrEmpty(volumeNovel.DiretorioImagemVolume));
             Assert.True(volumeNovel.ListaCapitulo.Any());
-            Assert.Equal(14, numeroDeCamposDoVolumeNovel);
+            Assert.Equal(16, numeroDeCamposDoVolumeNovel);
         }
 
         #endregion
@@ -193,7 +193,7 @@ namespace TsundokuTraducoes.Tests.Entities.Volumes
             Assert.NotEqual(new DateTime(), volumeComic.DataAlteracao);
             Assert.False(string.IsNullOrEmpty(volumeComic.DiretorioImagemVolume));
             Assert.False(volumeComic.ListaCapitulo.Any());
-            Assert.Equal(14, numeroDeCamposDoVolumeComic);
+            Assert.Equal(16, numeroDeCamposDoVolumeComic);
         }
 
         [Fact]
@@ -217,7 +217,7 @@ namespace TsundokuTraducoes.Tests.Entities.Volumes
             Assert.NotEqual(new DateTime(), volumeComic.DataAlteracao);
             Assert.False(string.IsNullOrEmpty(volumeComic.DiretorioImagemVolume));
             Assert.False(volumeComic.ListaCapitulo.Any());
-            Assert.Equal(14, numeroDeCamposDoVolumeComic);
+            Assert.Equal(16, numeroDeCamposDoVolumeComic);
 
         }
 
@@ -242,7 +242,7 @@ namespace TsundokuTraducoes.Tests.Entities.Volumes
             Assert.NotEqual(new DateTime(), volumeComic.DataAlteracao);
             Assert.False(string.IsNullOrEmpty(volumeComic.DiretorioImagemVolume));
             Assert.True(volumeComic.ListaCapitulo.Any());
-            Assert.Equal(14, numeroDeCamposDoVolumeComic);
+            Assert.Equal(16, numeroDeCamposDoVolumeComic);
         }
 
         #endregion

--- a/TsundokuTraducoes.Tests/Services/AppServices/Volume/VolumeAppServiceFactoryTestes.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/Volume/VolumeAppServiceFactoryTestes.cs
@@ -1,0 +1,40 @@
+﻿using AutoFixture;
+using TsundokuTraducoes.Entities.Entities.Obra;
+using TsundokuTraducoes.Entities.Entities.Volume;
+using TsundokuTraducoes.Tests.Utils;
+
+namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
+{
+    public class VolumeAppServiceFactoryTestes
+    {
+        #region => TESTES VOLUME COMIC APP SERVICE
+
+        public Comic GerarComic(Guid idComic)
+        {
+            return FixtureCustomizado.RetornaFixtureCustomizado.Build<Comic>().With(x => x.Id, idComic).Create();
+        }
+
+        public Comic GerarComic(Guid idComic, string slugObra)
+        {
+            return FixtureCustomizado.RetornaFixtureCustomizado.Build<Comic>().With(x => x.Id, idComic).With(x => x.Slug, slugObra).Create();
+        }
+
+        public List<VolumeComic> GerarListaVolumeComic(Guid idComic, List<Guid> listaIdsCapitulos)
+        {
+            var listaCapituloComic = new List<VolumeComic>();
+            listaIdsCapitulos
+                .ForEach(id => listaCapituloComic
+                    .Add(FixtureCustomizado.RetornaFixtureCustomizado
+                        .Build<VolumeComic>()
+                        .With(x => x.Id, id)
+                        .With(x => x.ComicId, idComic)
+                        .Create()
+                    )
+                );
+
+            return listaCapituloComic;
+        }
+
+        #endregion
+    }
+}

--- a/TsundokuTraducoes.Tests/Services/AppServices/Volume/VolumeAppServiceFactoryTestes.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/Volume/VolumeAppServiceFactoryTestes.cs
@@ -1,6 +1,9 @@
 ﻿using AutoFixture;
+using Newtonsoft.Json;
+using TsundokuTraducoes.Entities.Entities.Capitulo;
 using TsundokuTraducoes.Entities.Entities.Obra;
 using TsundokuTraducoes.Entities.Entities.Volume;
+using TsundokuTraducoes.Helpers.DTOs.Admin;
 using TsundokuTraducoes.Tests.Utils;
 
 namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
@@ -19,20 +22,61 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
             return FixtureCustomizado.RetornaFixtureCustomizado.Build<Comic>().With(x => x.Id, idComic).With(x => x.Slug, slugObra).Create();
         }
 
-        public List<VolumeComic> GerarListaVolumeComic(Guid idComic, List<Guid> listaIdsCapitulos)
+        public List<VolumeComic> GerarListaVolumeComic(Guid idComic, List<Guid> listaIdsVolumes, List<Guid> listaIdsCapitulos)
         {
-            var listaCapituloComic = new List<VolumeComic>();
-            listaIdsCapitulos
-                .ForEach(id => listaCapituloComic
+            var listaVolumesComic = new List<VolumeComic>();
+            listaIdsVolumes
+                .ForEach(id => listaVolumesComic
                     .Add(FixtureCustomizado.RetornaFixtureCustomizado
                         .Build<VolumeComic>()
                         .With(x => x.Id, id)
                         .With(x => x.ComicId, idComic)
+                        .With(x => x.ListaCapitulo, GerarListaCapituloComic(listaIdsCapitulos))
+                        .Create()
+                    )
+                );
+
+            return listaVolumesComic;
+        }
+
+        public List<CapituloComic> GerarListaCapituloComic(List<Guid> listaIdsCapitulos)
+        {
+            var listaCapituloComic = new List<CapituloComic>();
+            listaIdsCapitulos
+                .ForEach(id => listaCapituloComic
+                    .Add(FixtureCustomizado.RetornaFixtureCustomizado
+                        .Build<CapituloComic>()
+                        .With(x => x.Id, id)
+                        .With(x => x.ListaImagensJson, RetornaConteudoComic())
                         .Create()
                     )
                 );
 
             return listaCapituloComic;
+        }
+
+        public static string RetornaConteudoComic()
+        {
+            var lista = new List<EnderecoImagemDTO>
+            {
+               new EnderecoImagemDTO {
+                   Id=1,
+                   Ordem=1,
+                   Url="http://tsundoku.com.br/wp-content/uploads/2022/01/0-46.jpg"
+               },
+               new EnderecoImagemDTO {
+                  Id=2,
+                  Ordem=2,
+                  Url="http://tsundoku.com.br/wp-content/uploads/2022/01/0-47.jpg"
+               },
+               new EnderecoImagemDTO {
+                  Id=3,
+                  Ordem=3,
+                  Url="http://tsundoku.com.br/wp-content/uploads/2022/01/1-60.jpg"
+               }
+            };
+
+            return JsonConvert.SerializeObject(lista);
         }
 
         #endregion

--- a/TsundokuTraducoes.Tests/Services/AppServices/Volume/VolumeAppServiceTestes.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/Volume/VolumeAppServiceTestes.cs
@@ -1,4 +1,5 @@
-﻿using HttpContextMoq;
+﻿using AutoMapper;
+using HttpContextMoq;
 using HttpContextMoq.Extensions;
 using Moq;
 using TsundokuTraducoes.Api.Helpers;
@@ -7,23 +8,35 @@ using TsundokuTraducoes.Entities.Entities.Obra;
 using TsundokuTraducoes.Entities.Entities.Volume;
 using TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
 using TsundokuTraducoes.Services.AppServices;
+using TsundokuTraducoes.Services.Profiles;
 
 namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
 {
     public class VolumeAppServiceTestes
     {
+        private readonly IMapper _mapper;
         private readonly Mock<IVolumeComicService> _volumeComicServiceMock;
         private readonly Mock<IObraService> _ObraServiceMock;
         private readonly VolumeComicAppService _volumeComicAppServiceMock;
 
         public VolumeAppServiceTestes()
         {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile(new VolumeProfile());
+                cfg.AddProfile(new CapituloProfile());
+                cfg.AddProfile(new ObraProfile());
+                cfg.AddProfile(new GeneroProfile());
+            });
+
+            _mapper = config.CreateMapper();
             _volumeComicServiceMock = new Mock<IVolumeComicService>();
             _ObraServiceMock = new Mock<IObraService>();
 
             _volumeComicAppServiceMock = new VolumeComicAppService(
                _volumeComicServiceMock.Object,
-               _ObraServiceMock.Object
+               _ObraServiceMock.Object,
+               _mapper
             );
         }
 
@@ -46,9 +59,17 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
                 Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
             ];
 
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
             var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
             Comic comic = volumeAppServiceFactory.GerarComic(IdObra);
-            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes, listaIdsCapitulos);
 
             var scheme = "https";
             var host = "localhost";
@@ -91,9 +112,17 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
                 Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
             ];
 
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
             var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
             Comic comic = volumeAppServiceFactory.GerarComic(IdObra);
-            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes, listaIdsCapitulos);
 
             var scheme = "https";
             var host = "localhost";
@@ -136,9 +165,17 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
                 Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
             ];
 
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
             var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
             Comic comic = volumeAppServiceFactory.GerarComic(IdObra);
-            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes, listaIdsCapitulos);
 
             var scheme = "https";
             var host = "localhost";
@@ -171,10 +208,11 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
             var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
 
             List<Guid> listaIdsVolumes = [];
+            List<Guid> listaIdsCapitulos = [];
 
             var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
             Comic comic = volumeAppServiceFactory.GerarComic(IdObra);
-            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes, listaIdsCapitulos);
 
             var scheme = "https";
             var host = "localhost";
@@ -215,9 +253,17 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
                 Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
             ];
 
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
             var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
             Comic comic = null;
-            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes, listaIdsCapitulos);
 
             // Mock
             _ObraServiceMock.Setup(x => x.RetornaComicPorId(IdObra)).Returns(comic);
@@ -249,9 +295,17 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
                 Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
             ];
 
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
             var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
             Comic comic = volumeAppServiceFactory.GerarComic(IdObra, slugObra);
-            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes, listaIdsCapitulos);
 
             var scheme = "https";
             var host = "localhost";
@@ -295,9 +349,17 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
                 Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
             ];
 
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
             var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
             Comic comic = volumeAppServiceFactory.GerarComic(IdObra, slugObra);
-            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes, listaIdsCapitulos);
 
             var scheme = "https";
             var host = "localhost";
@@ -342,9 +404,17 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
                 Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
             ];
 
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
             var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
             Comic comic = volumeAppServiceFactory.GerarComic(IdObra, slugObra);
-            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes, listaIdsCapitulos);
 
             var scheme = "https";
             var host = "localhost";
@@ -379,10 +449,11 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
             var slugObra = "slug-comic-teste";
 
             List<Guid> listaIdsVolumes = [];
+            List<Guid> listaIdsCapitulos = [];
 
             var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
             Comic comic = volumeAppServiceFactory.GerarComic(IdObra, slugObra);
-            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes, listaIdsCapitulos);
 
             var scheme = "https";
             var host = "localhost";
@@ -424,9 +495,17 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
                 Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
             ];
 
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("0000000a-111b-222c-333d-44444444444e"),
+                Guid.Parse("000000aa-11bb-22cc-33dd-4444444444ee"),
+                Guid.Parse("00000aaa-1bbb-2ccc-3ddd-444444444eee"),
+                Guid.Parse("0000aaaa-bbbb-cccc-dddd-44444444eeee")
+            ];
+
             var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
             Comic comic = null;
-            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes, listaIdsCapitulos);
 
             // Mock
             _ObraServiceMock.Setup(x => x.RetornaComicPorSlug(slugObra)).Returns(comic);

--- a/TsundokuTraducoes.Tests/Services/AppServices/Volume/VolumeAppServiceTestes.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/Volume/VolumeAppServiceTestes.cs
@@ -1,0 +1,444 @@
+﻿using HttpContextMoq;
+using HttpContextMoq.Extensions;
+using Moq;
+using TsundokuTraducoes.Api.Helpers;
+using TsundokuTraducoes.Domain.Interfaces.Services;
+using TsundokuTraducoes.Entities.Entities.Obra;
+using TsundokuTraducoes.Entities.Entities.Volume;
+using TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
+using TsundokuTraducoes.Services.AppServices;
+
+namespace TsundokuTraducoes.Tests.Services.AppServices.Volume
+{
+    public class VolumeAppServiceTestes
+    {
+        private readonly Mock<IVolumeComicService> _volumeComicServiceMock;
+        private readonly Mock<IObraService> _ObraServiceMock;
+        private readonly VolumeComicAppService _volumeComicAppServiceMock;
+
+        public VolumeAppServiceTestes()
+        {
+            _volumeComicServiceMock = new Mock<IVolumeComicService>();
+            _ObraServiceMock = new Mock<IObraService>();
+
+            _volumeComicAppServiceMock = new VolumeComicAppService(
+               _volumeComicServiceMock.Object,
+               _ObraServiceMock.Object
+            );
+        }
+
+        #region => TESTES VOLUME COMIC APP SERVICE
+
+        [Fact]
+        public void DeveRetornarVolume_ComLinksParaProximoEAnterior_NaBuscaPorIdObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+
+            List<Guid> listaIdsVolumes =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
+            Comic comic = volumeAppServiceFactory.GerarComic(IdObra);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Id}?skip=1";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoVolumeComic = new List<RetornoVolumeComic>();
+
+            listaVolumesComic
+                .ForEach(volumeComic => retornoListaRetornoVolumeComic
+                    .Add(_volumeComicAppServiceMock
+                        .TrataRetornoVolumeComic(volumeComic)
+                    )
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoVolumesComics(httpContext, retornoListaRetornoVolumeComic, 1, null);
+
+            Assert.Equal(6, objetoRetorno.Data.Count);
+            Assert.Equal(7, objetoRetorno.Total);
+            Assert.Contains($"{comic.Id}?Skip=7&Take=6", objetoRetorno.Proxima);
+            Assert.Contains($"{comic.Id}?Skip=0&Take=6", objetoRetorno.Anterior);
+        }
+
+        [Fact]
+        public void DeveRetornarVolume_ComLinksParaProximoEAnteriorNull_NaBuscaPorIdObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+
+            List<Guid> listaIdsVolumes =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
+            Comic comic = volumeAppServiceFactory.GerarComic(IdObra);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Id}?skip=0&take=6";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoVolumeComic = new List<RetornoVolumeComic>();
+
+            listaVolumesComic
+                .ForEach(volumeComic => retornoListaRetornoVolumeComic
+                    .Add(_volumeComicAppServiceMock
+                        .TrataRetornoVolumeComic(volumeComic)
+                    )
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoVolumesComics(httpContext, retornoListaRetornoVolumeComic, 0, 6);
+
+            Assert.Equal(6, objetoRetorno.Data.Count);
+            Assert.Equal(7, objetoRetorno.Total);
+            Assert.Contains($"{comic.Id}?Skip=6&Take=6", objetoRetorno.Proxima);
+            Assert.Null(objetoRetorno.Anterior);
+        }
+
+        [Fact]
+        public void DeveRetornarVolume_ComLinksParaAnteriorEProximoNull_NaBuscaPorIdObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+
+            List<Guid> listaIdsVolumes =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
+            Comic comic = volumeAppServiceFactory.GerarComic(IdObra);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Id}?skip=6&take=6";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoVolumeComic = new List<RetornoVolumeComic>();
+
+            listaVolumesComic
+                .ForEach(volumeComic => retornoListaRetornoVolumeComic
+                    .Add(_volumeComicAppServiceMock
+                        .TrataRetornoVolumeComic(volumeComic)
+                    )
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoVolumesComics(httpContext, retornoListaRetornoVolumeComic, 6, 6);
+
+            Assert.Single(objetoRetorno.Data);
+            Assert.Equal(7, objetoRetorno.Total);
+            Assert.Null(objetoRetorno.Proxima);
+            Assert.Contains($"{comic.Id}?Skip=0&Take=6", objetoRetorno.Anterior);
+        }
+
+        [Fact]
+        public void DeveRetornarFalse_QuandoVolumeNaoEncontrado_NaBuscaPorIdObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+
+            List<Guid> listaIdsVolumes = [];
+
+            var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
+            Comic comic = volumeAppServiceFactory.GerarComic(IdObra);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Id}?skip=6&take=6";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoVolumeComic = new List<RetornoVolumeComic>();
+
+            listaVolumesComic
+                .ForEach(volumeComic => retornoListaRetornoVolumeComic
+                    .Add(_volumeComicAppServiceMock
+                        .TrataRetornoVolumeComic(volumeComic)
+                    )
+                );
+
+            var result = _volumeComicAppServiceMock.ValidaExisteListaVolume(listaVolumesComic);
+
+            Assert.False(result.IsSuccess);
+            Assert.Contains("Lista de volumes não encontrado para essa obra!", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public async Task DeveRetornarNull_QuandoObraNaoEncontrada_NaBuscaPorIdObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+
+            List<Guid> listaIdsVolumes =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
+            Comic comic = null;
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+
+            // Mock
+            _ObraServiceMock.Setup(x => x.RetornaComicPorId(IdObra)).Returns(comic);
+
+            // Assert
+            var result = await _volumeComicAppServiceMock.ObterVolumesComicPorIdObra(IdObra);
+
+            Assert.False(result.IsSuccess);
+            Assert.Null(result.ValueOrDefault);
+            Assert.Contains("Obra não encontrada!", result.Errors[0].Message);
+        }
+
+
+        [Fact]
+        public void DeveRetornarVolume_ComLinksParaProximoEAnterior_NaBuscaPorSlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsVolumes =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
+            Comic comic = volumeAppServiceFactory.GerarComic(IdObra, slugObra);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Slug}?skip=1";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoVolumeComic = new List<RetornoVolumeComic>();
+
+            listaVolumesComic
+                .ForEach(volumeComic => retornoListaRetornoVolumeComic
+                    .Add(_volumeComicAppServiceMock
+                        .TrataRetornoVolumeComic(volumeComic)
+                    )
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoVolumesComics(httpContext, retornoListaRetornoVolumeComic, 1, null);
+
+            Assert.Equal(6, objetoRetorno.Data.Count);
+            Assert.Equal(7, objetoRetorno.Total);
+            Assert.Contains($"{comic.Slug}?Skip=7&Take=6", objetoRetorno.Proxima);
+            Assert.Contains($"{comic.Slug}?Skip=0&Take=6", objetoRetorno.Anterior);
+        }
+
+        [Fact]
+        public void DeveRetornarVolume_ComLinksParaProximoEAnteriorNull_NaBuscaPorSlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsVolumes =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
+            Comic comic = volumeAppServiceFactory.GerarComic(IdObra, slugObra);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Slug}?skip=0&take=6";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoVolumeComic = new List<RetornoVolumeComic>();
+
+            listaVolumesComic
+                .ForEach(volumeComic => retornoListaRetornoVolumeComic
+                    .Add(_volumeComicAppServiceMock
+                        .TrataRetornoVolumeComic(volumeComic)
+                    )
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoVolumesComics(httpContext, retornoListaRetornoVolumeComic, 0, 6);
+
+            Assert.Equal(slugObra, comic.Slug);
+            Assert.Equal(6, objetoRetorno.Data.Count);
+            Assert.Equal(7, objetoRetorno.Total);
+            Assert.Contains($"{comic.Slug}?Skip=6&Take=6", objetoRetorno.Proxima);
+            Assert.Null(objetoRetorno.Anterior);
+        }
+
+        [Fact]
+        public void DeveRetornarVolume_ComLinksParaAnteriorEProximoNull_NaBuscaPorSlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsVolumes =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
+            Comic comic = volumeAppServiceFactory.GerarComic(IdObra, slugObra);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Slug}?skip=6&take=6";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoVolumeComic = new List<RetornoVolumeComic>();
+
+            listaVolumesComic
+                .ForEach(volumeComic => retornoListaRetornoVolumeComic
+                    .Add(_volumeComicAppServiceMock
+                        .TrataRetornoVolumeComic(volumeComic)
+                    )
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoVolumesComics(httpContext, retornoListaRetornoVolumeComic, 6, 6);
+
+            Assert.Equal(slugObra, comic.Slug);
+            Assert.Single(objetoRetorno.Data);
+            Assert.Equal(7, objetoRetorno.Total);
+            Assert.Contains($"{comic.Slug}?Skip=0&Take=6", objetoRetorno.Anterior);
+            Assert.Null(objetoRetorno.Proxima);
+        }
+
+        [Fact]
+        public void DeveRetornarFalse_QuandoVolumeNaoEncontrado_NaBuscaPorIdVolumeESlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsVolumes = [];
+
+            var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
+            Comic comic = volumeAppServiceFactory.GerarComic(IdObra, slugObra);
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Id}?skip=6&take=6";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoVolumeComic = new List<RetornoVolumeComic>();
+
+            listaVolumesComic
+                .ForEach(volumeComic => retornoListaRetornoVolumeComic
+                    .Add(_volumeComicAppServiceMock
+                        .TrataRetornoVolumeComic(volumeComic)
+                    )
+                );
+
+            var result = _volumeComicAppServiceMock.ValidaExisteListaVolume(listaVolumesComic);
+
+            Assert.False(result.IsSuccess);
+            Assert.Contains("Lista de volumes não encontrado para essa obra!", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public async Task DeveRetornarNull_QuandoObraNaoEncontrada_NaBuscaPorIdVolumeESlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsVolumes =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var volumeAppServiceFactory = new VolumeAppServiceFactoryTestes();
+            Comic comic = null;
+            List<VolumeComic> listaVolumesComic = volumeAppServiceFactory.GerarListaVolumeComic(IdObra, listaIdsVolumes);
+
+            // Mock
+            _ObraServiceMock.Setup(x => x.RetornaComicPorSlug(slugObra)).Returns(comic);
+
+            // Assert
+            var result = await _volumeComicAppServiceMock.ObterVolumesComicPorIdObra(IdObra);
+
+            Assert.False(result.IsSuccess);
+            Assert.Null(result.ValueOrDefault);
+            Assert.Contains("Obra não encontrada!", result.Errors[0].Message);
+        }
+
+        #endregion
+    }
+}

--- a/TsundokuTraducoes/Controllers/Publico/comic/VolumesComicsController.cs
+++ b/TsundokuTraducoes/Controllers/Publico/comic/VolumesComicsController.cs
@@ -28,7 +28,7 @@ namespace TsundokuTraducoes.Api.Controllers.Publico.comic
             if (result.IsFailed)
                 return NotFound(result.Errors[0].Message);
 
-            var objetoRetorno = RequestHelper.CriarObjetoRetonoVolumesPorSlugComics(HttpContext, result.Value, skip, take);
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoVolumesComics(HttpContext, result.Value, skip, take);
             return Ok(objetoRetorno);
         }
     }

--- a/TsundokuTraducoes/Controllers/Publico/comic/VolumesComicsController.cs
+++ b/TsundokuTraducoes/Controllers/Publico/comic/VolumesComicsController.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
+using TsundokuTraducoes.Api.Helpers;
+using TsundokuTraducoes.Helpers.Services.Interfaces;
+using TsundokuTraducoes.Services.AppServices.Interfaces;
+
+namespace TsundokuTraducoes.Api.Controllers.Publico.comic
+{
+    [ApiController]
+    public class VolumesComicsController(IVolumeComicAppService service) : Controller, IBaseService<IVolumeComicAppService>
+    {
+        [HttpGet("api/comics/volumes/{idObra}")]
+        public async Task<IActionResult> ObterVolumesComicPorIdObra(Guid idObra, [FromQuery] int? skip, int? take)
+        {
+            var result = await service.ObterVolumesComicPorIdObra(idObra);
+            if (result.IsFailed)
+                return NotFound(result.Errors[0].Message);
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoVolumesComics(HttpContext, result.Value, skip, take);
+            return Ok(objetoRetorno);
+        }
+
+        [HttpGet("api/comics/volumes/slug/{slugObra}")]
+        public async Task<IActionResult> ObterVolumesComicPorSlugObra(string slugObra, [FromQuery] int? skip, int? take)
+        {
+            var result = await service.ObterVolumesComicPorSlugObra(slugObra);
+            if (result.IsFailed)
+                return NotFound(result.Errors[0].Message);
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoVolumesPorSlugComics(HttpContext, result.Value, skip, take);
+            return Ok(objetoRetorno);
+        }
+    }
+}

--- a/TsundokuTraducoes/Controllers/Publico/comic/VolumesComicsController.cs
+++ b/TsundokuTraducoes/Controllers/Publico/comic/VolumesComicsController.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using TsundokuTraducoes.Api.Helpers;
+using TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
 using TsundokuTraducoes.Helpers.Services.Interfaces;
 using TsundokuTraducoes.Services.AppServices.Interfaces;
 
@@ -11,6 +12,7 @@ namespace TsundokuTraducoes.Api.Controllers.Publico.comic
     public class VolumesComicsController(IVolumeComicAppService service) : Controller, IBaseService<IVolumeComicAppService>
     {
         [HttpGet("api/comics/volumes/{idObra}")]
+        [ProducesResponseType(typeof(RetornoVolumeComic), statusCode: 200)]
         public async Task<IActionResult> ObterVolumesComicPorIdObra(Guid idObra, [FromQuery] int? skip, int? take)
         {
             var result = await service.ObterVolumesComicPorIdObra(idObra);
@@ -22,6 +24,7 @@ namespace TsundokuTraducoes.Api.Controllers.Publico.comic
         }
 
         [HttpGet("api/comics/volumes/slug/{slugObra}")]
+        [ProducesResponseType(typeof(RetornoVolumeComic), statusCode: 200)]
         public async Task<IActionResult> ObterVolumesComicPorSlugObra(string slugObra, [FromQuery] int? skip, int? take)
         {
             var result = await service.ObterVolumesComicPorSlugObra(slugObra);

--- a/TsundokuTraducoes/Extensions/DependenciesExtension.cs
+++ b/TsundokuTraducoes/Extensions/DependenciesExtension.cs
@@ -31,6 +31,7 @@ namespace TsundokuTraducoes.Api.Extensions
           
             services.AddScoped<ICapituloComicRepository, CapituloComicRepository>();
             services.AddScoped<ICapituloNovelRepository, CapituloNovelRepository>();  
+            services.AddScoped<IVolumeComicRepository,VolumeComicRepository>();
         }
 
         public static void AddServices(this IServiceCollection services)
@@ -51,10 +52,14 @@ namespace TsundokuTraducoes.Api.Extensions
             services.AddScoped<IVolumeService, VolumeService>();
 
             services.AddScoped(typeof(IBaseService<>), typeof(BaseService<>));
+
             services.AddScoped<ICapituloComicAppService, CapituloComicAppService>();
             services.AddScoped<ICapituloComicService, CapituloComicService>();
             services.AddScoped<ICapituloNovelAppService, CapituloNovelAppService>();
             services.AddScoped<ICapituloNovelService, CapituloNovelService>();
+
+            services.AddScoped<IVolumeComicAppService, VolumeComicAppService>();
+            services.AddScoped<IVolumeComicService, VolumeComicService>();
         }
     }
 }

--- a/TsundokuTraducoes/Helpers/RequestHelper.cs
+++ b/TsundokuTraducoes/Helpers/RequestHelper.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Http;
-using MySqlX.XDevAPI;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/TsundokuTraducoes/Helpers/RequestHelper.cs
+++ b/TsundokuTraducoes/Helpers/RequestHelper.cs
@@ -226,22 +226,6 @@ namespace TsundokuTraducoes.Api.Helpers
             return new ObjetoRetornoVolumeComicResponse { Anterior = anterior, Proxima = proxima, Data = dados, Total = total };
         }
 
-        public static ObjetoRetornoVolumeComicResponse CriarObjetoRetonoVolumesPorSlugComics(HttpContext httpContext, List<RetornoVolumeComic> listaRetornoVolumeComic, int? skip, int? take)
-        {
-            var itensPorPagina = ValidacaoRequest.RetornaTakeTratado(take);
-            var itensPulados = ValidacaoRequest.RetornaSkipTratado(skip, itensPorPagina);
-
-            var dados = listaRetornoVolumeComic.Skip(itensPorPagina).Take(itensPulados).ToList();
-
-            var request = httpContext.Request;
-            var url = $"{request.Scheme}://{request.Host}{request.Path}";
-
-            string proxima = RetornaLinkPaginacaoProxima(itensPorPagina, itensPulados, dados, url);
-            string anterior = RetornaLinkPaginacaoAnterior(itensPorPagina, itensPulados, url);
-
-            return new ObjetoRetornoVolumeComicResponse { Anterior = anterior, Proxima = proxima, Data = dados };
-        }
-
         private static string RetornaLinkPaginacaoAnterior(int itensPorPagina, int itensPulados, string url)
         {
             string anterior = null;

--- a/TsundokuTraducoes/Helpers/RequestHelper.cs
+++ b/TsundokuTraducoes/Helpers/RequestHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using MySqlX.XDevAPI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -204,12 +205,60 @@ namespace TsundokuTraducoes.Api.Helpers
             return new ObjetoRetornoCapituloNovelResponse { Anterior = anterior, Proxima = proxima, Data = retornoCapituloNovel };
         }
 
+        public static ObjetoRetornoVolumeComicResponse CriarObjetoRetonoVolumesComics(HttpContext httpContext, List<RetornoVolumeComic> listaRetornoVolumeComic, int? skip, int? take)
+        {
+            if (!skip.HasValue && !take.HasValue)
+            {
+                return new ObjetoRetornoVolumeComicResponse { Anterior = null, Proxima = null, Data = listaRetornoVolumeComic, Total = listaRetornoVolumeComic.Count };
+            }
+
+            var itensPorPagina = ValidacaoRequest.RetornaTakeTratado(take);
+            var itensPulados = ValidacaoRequest.RetornaSkipTratado(skip, itensPorPagina);
+
+            var dados = listaRetornoVolumeComic.Skip(itensPulados).Take(itensPorPagina).ToList();
+            var total = listaRetornoVolumeComic.Count;
+
+            var request = httpContext.Request;
+            var url = $"{request.Scheme}://{request.Host}{request.Path}";
+
+            string proxima = RetornaLinkPaginacaoProxima(itensPorPagina, itensPulados, dados, url);
+            string anterior = RetornaLinkPaginacaoAnterior(itensPorPagina, itensPulados, url);
+
+            return new ObjetoRetornoVolumeComicResponse { Anterior = anterior, Proxima = proxima, Data = dados, Total = total };
+        }
+
+        public static ObjetoRetornoVolumeComicResponse CriarObjetoRetonoVolumesPorSlugComics(HttpContext httpContext, List<RetornoVolumeComic> listaRetornoVolumeComic, int? skip, int? take)
+        {
+            var itensPorPagina = ValidacaoRequest.RetornaTakeTratado(take);
+            var itensPulados = ValidacaoRequest.RetornaSkipTratado(skip, itensPorPagina);
+
+            var dados = listaRetornoVolumeComic.Skip(itensPorPagina).Take(itensPulados).ToList();
+
+            var request = httpContext.Request;
+            var url = $"{request.Scheme}://{request.Host}{request.Path}";
+
+            string proxima = RetornaLinkPaginacaoProxima(itensPorPagina, itensPulados, dados, url);
+            string anterior = RetornaLinkPaginacaoAnterior(itensPorPagina, itensPulados, url);
+
+            return new ObjetoRetornoVolumeComicResponse { Anterior = anterior, Proxima = proxima, Data = dados };
+        }
+
         private static string RetornaLinkPaginacaoAnterior(int itensPorPagina, int itensPulados, string url)
         {
             string anterior = null;
             if (itensPulados > 0)
             {
-                anterior = $"{url}?Skip={itensPulados - itensPorPagina}&Take={itensPorPagina}";
+                int skip = 0;
+                if (itensPulados < itensPorPagina)
+                {
+                    skip = --itensPulados;
+                }
+                else
+                {
+                    skip = itensPulados - itensPorPagina;
+                }
+
+                anterior = $"{url}?Skip={skip}&Take={itensPorPagina}";
             }
 
             return anterior;
@@ -260,6 +309,6 @@ namespace TsundokuTraducoes.Api.Helpers
                 string.IsNullOrEmpty(idObra) ? "" : $"&IdObra={idObra}";
 
             return queryStringComposta;
-        }
+        }       
     }
 }


### PR DESCRIPTION
## Descreva as mudanças feitas nessa PR:
- Criação das migrations para atualização na base de dados
- Criação da classe/interface VolumeComicRepository.cs/IVolumeComicRepository.cs
- Criação da classe/interface VolumeComicService.cs/IVolumeComicService.cs
- Adição dos campos Publicado/OrdemVolume nas entidades VolumeComic.cs/VolumeNovel.cs
- Criação da classe ObjetoRetornoVolumeComicResponse.cs
- Atualização da classe RetornoCapituloComic.cs com o campo Publicado
- Criação da classe RetornoVolumeComic.cs
- Criação da classe/interface VolumeComicAppService.cs/IVolumeComicAppService.cs
- Atualização da classe VolumeProfile.cs
- Atualização da classe VolumesTestes.cs
- Criação da classe VolumeAppServiceFactoryTestes.cs
- Criação da classe VolumeAppServiceTestes.cs
- Criação da classe VolumesComicsController.cs
- Atualização da classe DependenciesExtension.cs
- Adição do método ObjetoRetornoVolumeComicResponse e correção do método RetornaLinkPaginacaoAnterior na classe RequestHelper.cs

- Rotas adicionadas:
`/api/comics/volumes/{idObra}`
`/api/comics/volumes/{slugObra}`

## Ela resolve alguma issue? Informe o número:
[#74](https://github.com/tsundokuapp/tsundoku-api/issues/74)

## Preencha o checklist antes de enviar a PR (delete o que não usar):
- [x] New feature (adiciona nova funcionalidade).
- [x] Esta PR possui teste inclusos.