### PR TITLE
PR para correção rotas api/obras/novels/recentes e api/obras/comics/recentes

### DIFF
--- a/TsundokuTraducoes.Data/Repositories/ObrasRepository.cs
+++ b/TsundokuTraducoes.Data/Repositories/ObrasRepository.cs
@@ -100,16 +100,24 @@ namespace TsundokuTraducoes.Data.Repositories
         }
 
         
-        public async Task<List<RetornoObras>> ObterListaNovelsRecentes()
+        public async Task<List<Novel>> ObterListaNovelsRecentes()
         {
-            var listaNovels = await _context.Novels.AsNoTracking().OrderByDescending(o => o.DataInclusao).ToListAsync();
-            return TrataListaRetornoNovel(listaNovels);
+            return await _context
+                .Novels
+                .AsNoTracking()
+                .Where(x => x.Volumes.Where(x => x.ListaCapitulo.Count != 0).Any())
+                .OrderByDescending(o => o.DataAtualizacaoUltimoCapitulo)
+                .ToListAsync();
         }
         
-        public async Task<List<RetornoObras>> ObterListaComicsRecentes()
-        {
-            var listaComics = await _context.Comics.AsNoTracking().OrderByDescending(o => o.DataInclusao).ToListAsync();
-            return TrataListaRetornoComic(listaComics);
+        public async Task<List<Comic>> ObterListaComicsRecentes()
+        {   
+            return await _context
+                .Comics
+                .AsNoTracking()
+                .Where(x => x.Volumes.Where(x => x.ListaCapitulo.Count != 0).Any())
+                .OrderByDescending(o => o.DataAtualizacaoUltimoCapitulo)
+                .ToListAsync();
         }
 
 
@@ -313,54 +321,6 @@ namespace TsundokuTraducoes.Data.Repositories
                         {condicaoConsulta} ";
         }
         
-
-        public static List<RetornoObras> TrataListaRetornoNovel(List<Novel> listaNovels)
-        {
-            var listaRetornoObra = new List<RetornoObras>();
-
-            foreach (var obra in listaNovels)
-            {
-                listaRetornoObra.Add(TrataRetornoNovel(obra));
-            }
-
-            return listaRetornoObra;
-        }
-
-        public static List<RetornoObras> TrataListaRetornoComic(List<Comic> listaNovels)
-        {
-            var listaRetornoObra = new List<RetornoObras>();
-
-            foreach (var obra in listaNovels)
-            {
-                listaRetornoObra.Add(TrataRetornoComic(obra));
-            }
-
-            return listaRetornoObra;
-        }
-        
-        
-        private static RetornoObras TrataRetornoNovel(Novel obra)
-        {
-            return new RetornoObras
-            {
-                UrlCapa = !string.IsNullOrEmpty(obra.ImagemCapaUltimoVolume)
-                ? obra.ImagemCapaUltimoVolume
-                : obra.ImagemCapaPrincipal,
-                
-                Titulo = obra.Titulo,
-                TipoObra = obra.TipoObra,
-                Alias = obra.Alias,
-                Autor = obra.Autor,
-                DescritivoVolume = obra.NumeroUltimoVolume,
-                Slug = obra.Slug,
-                Id = obra.Id,
-                TituloAlternativo = obra.TituloAlternativo,
-                StatusObra = obra.StatusObra,
-                ListaGeneros = TrataRetornoListaGeneros(obra.GenerosNovel),
-                Publicado = obra.Publicado
-            };
-        }
-        
         public static RetornoNovel TrataRetornoNovelUnica(Novel obra)
         {
             return new RetornoNovel()
@@ -390,7 +350,6 @@ namespace TsundokuTraducoes.Data.Repositories
             };
         }
 
-
         public static RetornoComic TrataRetornoComicUnica(Comic obra)
         {
             return new RetornoComic()
@@ -418,25 +377,6 @@ namespace TsundokuTraducoes.Data.Repositories
                 Observacao = obra.Observacao,
             };
         }
-
-        private static RetornoObras TrataRetornoComic(Comic obra)
-        {
-            return new RetornoObras
-            {
-                UrlCapa = !string.IsNullOrEmpty(obra.ImagemCapaUltimoVolume)
-                ? obra.ImagemCapaUltimoVolume
-                : obra.ImagemCapaPrincipal,
-                
-                Titulo = obra.Titulo,
-                TipoObra = obra.TipoObra,
-                Alias = obra.Alias,
-                Autor = obra.Autor,
-                DescritivoVolume = obra.NumeroUltimoVolume,
-                Slug = obra.Slug,
-                Id = obra.Id
-            };
-        }
-
 
         private static void TrataListaRetornoCapitulo(List<RetornoCapitulosHome> listaRetornoCapitulos)
         {

--- a/TsundokuTraducoes.Domain/Interfaces/Repositories/IObrasRepository.cs
+++ b/TsundokuTraducoes.Domain/Interfaces/Repositories/IObrasRepository.cs
@@ -13,8 +13,8 @@ namespace TsundokuTraducoes.Domain.Interfaces.Repositories
         Task<List<Novel>> ObterListaNovelsRecomendadas();
         Task<List<Comic>> ObterListaComicsRecomendadas();
 
-        Task<List<RetornoObras>> ObterListaNovelsRecentes();
-        Task<List<RetornoObras>> ObterListaComicsRecentes();
+        Task<List<Novel>> ObterListaNovelsRecentes();
+        Task<List<Comic>> ObterListaComicsRecentes();
         
         Task<Novel> ObterNovelPorId(Guid id);
         Task<Novel> ObterNovelPorSlug(string slug);

--- a/TsundokuTraducoes.Domain/Interfaces/Services/IObrasService.cs
+++ b/TsundokuTraducoes.Domain/Interfaces/Services/IObrasService.cs
@@ -8,13 +8,13 @@ namespace TsundokuTraducoes.Domain.Interfaces.Services
     public interface IObrasService
     {
         Task<List<Novel>> ObterListaNovels(RequestObras requestObras);
-        Task<List<RetornoObras>> ObterListaNovelsRecentes();        
+        Task<List<Novel>> ObterListaNovelsRecentes();        
         Task<Novel> ObterNovelPorId(Guid id);
         Task<Novel> ObterNovelPorSlug(string slug);
         Task<List<Novel>> ObterListaNovelsRecomendadas();
 
         Task<List<Comic>> ObterListaComics(RequestObras requestObras);
-        Task<List<RetornoObras>> ObterListaComicsRecentes();
+        Task<List<Comic>> ObterListaComicsRecentes();
         Task<Comic> ObterComicPorId(Guid id);
         Task<Comic> ObterComicPorSlug(string slug);        
         Task<List<Comic>> ObterListaComicsRecomendadas();

--- a/TsundokuTraducoes.Domain/Services/ObrasServices.cs
+++ b/TsundokuTraducoes.Domain/Services/ObrasServices.cs
@@ -21,7 +21,7 @@ namespace TsundokuTraducoes.Domain.Services
             return await _obrasRepository.ObterListaNovels(requestObras);
         }
         
-        public async Task<List<RetornoObras>> ObterListaNovelsRecentes()
+        public async Task<List<Novel>> ObterListaNovelsRecentes()
         {
             return await _obrasRepository.ObterListaNovelsRecentes();
         }
@@ -47,7 +47,7 @@ namespace TsundokuTraducoes.Domain.Services
             return await _obrasRepository.ObterListaComics(requestObras);
         }        
         
-        public async Task<List<RetornoObras>> ObterListaComicsRecentes()
+        public async Task<List<Comic>> ObterListaComicsRecentes()
         {
             return await _obrasRepository.ObterListaComicsRecentes();
         }

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/Response/ObjetoRetornoComicsRecentes.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/Response/ObjetoRetornoComicsRecentes.cs
@@ -1,0 +1,10 @@
+﻿namespace TsundokuTraducoes.Helpers.DTOs.Public.Retorno.Response
+{
+    public class ObjetoRetornoComicsRecentes
+    {
+        public string Proxima { get; set; }
+        public string Anterior { get; set; }
+        public List<RetornoComicsRecentes> Data { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/Response/ObjetoRetornoNovelsRecentes.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/Response/ObjetoRetornoNovelsRecentes.cs
@@ -1,0 +1,10 @@
+﻿namespace TsundokuTraducoes.Helpers.DTOs.Public.Retorno.Response
+{
+    public class ObjetoRetornoNovelsRecentes
+    {
+        public string Proxima { get; set; }
+        public string Anterior { get; set; }
+        public List<RetornoNovelsRecentes> Data { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoComicsRecentes.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoComicsRecentes.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace TsundokuTraducoes.Helpers.DTOs.Public.Retorno
+{
+    public class RetornoComicsRecentes
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string UrlCapaPrincipal { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string UrlCapaVolume { get; set; }
+
+        public string Titulo { get; set; }
+        public string UrlCapa { get; set; }
+        public string Alias { get; set; }
+        public string Autor { get; set; }
+        public string DescritivoVolume { get; set; }
+        public string Slug { get; set; }
+        public string TipoObra { get; set; }
+        public Guid Id { get; set; }
+        public string TituloAlternativo { get; set; }
+        public string StatusObra { get; set; }
+        public bool Publicado { get; set; }
+    }
+}

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoNovelsRecentes.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoNovelsRecentes.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace TsundokuTraducoes.Helpers.DTOs.Public.Retorno
+{
+    public class RetornoNovelsRecentes
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string UrlCapaPrincipal { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string UrlCapaVolume { get; set; }
+
+        public string Titulo { get; set; }
+        public string UrlCapa { get; set; }
+        public string Alias { get; set; }
+        public string Autor { get; set; }
+        public string DescritivoVolume { get; set; }
+        public string Slug { get; set; }
+        public string TipoObra { get; set; }
+        public Guid Id { get; set; }
+        public string TituloAlternativo { get; set; }
+        public string StatusObra { get; set; }
+        public bool Publicado { get; set; }
+    }
+}

--- a/TsundokuTraducoes.Services/AppServices/Interfaces/IObrasAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/Interfaces/IObrasAppService.cs
@@ -7,12 +7,12 @@ namespace TsundokuTraducoes.Services.AppServices.Interfaces
     public interface IObrasAppService
     {
         Task<List<RetornoNovel>> ObterListaNovels(RequestObras requestObras);
-        Task<List<RetornoObras>> ObterListaNovelsRecentes();
+        Task<List<RetornoNovelsRecentes>> ObterListaNovelsRecentes();
         Task<Result<RetornoNovel>> ObterNovelPorId(Guid id);
         Task<Result<RetornoNovel>> ObterNovelPorSlug(string slug);
 
         Task<List<RetornoComic>> ObterListaComics(RequestObras requestObras);
-        Task<List<RetornoObras>> ObterListaComicsRecentes();
+        Task<List<RetornoComicsRecentes>> ObterListaComicsRecentes();
         Task<Result<RetornoComic>> ObterComicPorId(Guid id);
         Task<Result<RetornoComic>> ObterComicPorSlug(string slug);
 

--- a/TsundokuTraducoes.Services/AppServices/ObrasAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/ObrasAppService.cs
@@ -70,7 +70,7 @@ namespace TsundokuTraducoes.Services.AppServices
 
             foreach (var comic in listaComicRecentes)
             {
-                listaRetornoObrasRecentes.Add(TrataRetornoComicRecente(comic));
+                listaRetornoObrasRecentes.Add(TrataRetornoComicRecentes(comic));
             }
 
             return listaRetornoObrasRecentes;
@@ -343,7 +343,7 @@ namespace TsundokuTraducoes.Services.AppServices
             return listaGeneros;
         }
 
-        public static RetornoNovelsRecentes TrataRetornoNovelRecentes(Novel obra)
+        public RetornoNovelsRecentes TrataRetornoNovelRecentes(Novel obra)
         {
             return new RetornoNovelsRecentes
             {
@@ -364,7 +364,7 @@ namespace TsundokuTraducoes.Services.AppServices
             };
         }
 
-        public static RetornoComicsRecentes TrataRetornoComicRecente(Comic obra)
+        public RetornoComicsRecentes TrataRetornoComicRecentes(Comic obra)
         {
             return new RetornoComicsRecentes
             {

--- a/TsundokuTraducoes.Services/AppServices/ObrasAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/ObrasAppService.cs
@@ -50,16 +50,30 @@ namespace TsundokuTraducoes.Services.AppServices
         }
 
 
-        public async Task<List<RetornoObras>> ObterListaNovelsRecentes()
+        public async Task<List<RetornoNovelsRecentes>> ObterListaNovelsRecentes()
         {
-            var listaRetornoObra = await _obrasService.ObterListaNovelsRecentes();
-            return listaRetornoObra;
+            var listaRetornoObrasRecentes = new List<RetornoNovelsRecentes>();
+            var listaNovelsRecentes = await _obrasService.ObterListaNovelsRecentes();
+
+            foreach (var novel in listaNovelsRecentes)
+            {
+                listaRetornoObrasRecentes.Add(TrataRetornoNovelRecentes(novel));
+            }
+
+            return listaRetornoObrasRecentes;
         }
 
-        public async Task<List<RetornoObras>> ObterListaComicsRecentes()
+        public async Task<List<RetornoComicsRecentes>> ObterListaComicsRecentes()
         {
-            var listaRetornoObra = await _obrasService.ObterListaComicsRecentes();
-            return listaRetornoObra;
+            var listaRetornoObrasRecentes = new List<RetornoComicsRecentes>();
+            var listaComicRecentes = await _obrasService.ObterListaComicsRecentes();
+
+            foreach (var comic in listaComicRecentes)
+            {
+                listaRetornoObrasRecentes.Add(TrataRetornoComicRecente(comic));
+            }
+
+            return listaRetornoObrasRecentes;
         }
 
 
@@ -237,7 +251,7 @@ namespace TsundokuTraducoes.Services.AppServices
                 ListaGeneros = TrataRetornoListaGenerosNovel(obra.GenerosNovel),
                 Publicado = obra.Publicado
             };
-        }        
+        }
 
         public RetornoNovel TrataRetornoNovelUnica(Novel obra)
         {
@@ -327,6 +341,45 @@ namespace TsundokuTraducoes.Services.AppServices
             });
 
             return listaGeneros;
+        }
+
+        public static RetornoNovelsRecentes TrataRetornoNovelRecentes(Novel obra)
+        {
+            return new RetornoNovelsRecentes
+            {
+                UrlCapa = !string.IsNullOrEmpty(obra.ImagemCapaUltimoVolume)
+                ? obra.ImagemCapaUltimoVolume
+                : obra.ImagemCapaPrincipal,
+
+                Titulo = obra.Titulo,
+                TipoObra = obra.TipoObra,
+                Alias = obra.Alias,
+                Autor = obra.Autor,
+                DescritivoVolume = obra.NumeroUltimoVolume,
+                Slug = obra.Slug,
+                Id = obra.Id,
+                TituloAlternativo = obra.TituloAlternativo,
+                StatusObra = obra.StatusObra,
+                Publicado = obra.Publicado
+            };
+        }
+
+        public static RetornoComicsRecentes TrataRetornoComicRecente(Comic obra)
+        {
+            return new RetornoComicsRecentes
+            {
+                UrlCapa = !string.IsNullOrEmpty(obra.ImagemCapaUltimoVolume)
+                ? obra.ImagemCapaUltimoVolume
+                : obra.ImagemCapaPrincipal,
+
+                Titulo = obra.Titulo,
+                TipoObra = obra.TipoObra,
+                Alias = obra.Alias,
+                Autor = obra.Autor,
+                DescritivoVolume = obra.NumeroUltimoVolume,
+                Slug = obra.Slug,
+                Id = obra.Id
+            };
         }
     }
 }

--- a/TsundokuTraducoes.Services/Profiles/ObrasProfile.cs
+++ b/TsundokuTraducoes.Services/Profiles/ObrasProfile.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using TsundokuTraducoes.Entities.Entities.Obra;
 using TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
 
 namespace TsundokuTraducoes.Services.Profiles
@@ -8,6 +9,8 @@ namespace TsundokuTraducoes.Services.Profiles
         public ObrasProfile()
         {
             CreateMap<RetornoNovel, RetornoAppNovel>();
+            CreateMap<Novel, RetornoNovelsRecentes>();
+            CreateMap<Comic, RetornoComicsRecentes>();
         }
     }
 }

--- a/TsundokuTraducoes.Tests/Services/AppServices/AppServicesFactory.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/AppServicesFactory.cs
@@ -394,4 +394,54 @@ public class AppServicesFactory
 
         return comic.GenerosComic;
     }
+
+    public List<Novel> GerarListaNovelsRecentes(Dictionary<string, DateTime> dicionarioObrasRecentes)
+    {
+        var listaNovels = new List<Novel>();
+
+        var capitulo = FixtureCustomizado.RetornaFixtureCustomizado.Build<CapituloNovel>().Create();
+        var volume = FixtureCustomizado.RetornaFixtureCustomizado.Build<VolumeNovel>().With(x => x.ListaCapitulo, [capitulo]).Create();
+
+        foreach (var obra in dicionarioObrasRecentes)
+        {
+            listaNovels
+                .Add(FixtureCustomizado
+                    .RetornaFixtureCustomizado
+                    .Build<Novel>()
+                    .With(x => x.Titulo, obra.Key)
+                    .With(x => x.DataAtualizacaoUltimoCapitulo, obra.Value)
+                    .With(x => x.Volumes, [volume])
+                    .Create()
+                );
+        }
+        
+        return listaNovels.Where(x => x.Volumes.Where(x => x.ListaCapitulo.Count != 0).Any())
+                .OrderByDescending(o => o.DataAtualizacaoUltimoCapitulo)
+                .ToList();
+    }
+
+    public List<Comic> GerarListaComicsRecentes(Dictionary<string, DateTime> dicionarioObrasRecentes)
+    {
+        var listaComics = new List<Comic>();
+
+        var capitulo = FixtureCustomizado.RetornaFixtureCustomizado.Build<CapituloComic>().Create();
+        var volume = FixtureCustomizado.RetornaFixtureCustomizado.Build<VolumeComic>().With(x => x.ListaCapitulo, [capitulo]).Create();
+
+        foreach (var obra in dicionarioObrasRecentes)
+        {
+            listaComics
+                .Add(FixtureCustomizado
+                    .RetornaFixtureCustomizado
+                    .Build<Comic>()
+                    .With(x => x.Titulo, obra.Key)
+                    .With(x => x.DataAtualizacaoUltimoCapitulo, obra.Value)
+                    .With(x => x.Volumes, [volume])
+                    .Create()
+                );
+        }
+
+        return listaComics.Where(x => x.Volumes.Where(x => x.ListaCapitulo.Count != 0).Any())
+                .OrderByDescending(o => o.DataAtualizacaoUltimoCapitulo)
+                .ToList();
+    }
 }

--- a/TsundokuTraducoes.Tests/Services/AppServices/Obra/ObraAppServiceTestes.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/Obra/ObraAppServiceTestes.cs
@@ -9,16 +9,15 @@ using TsundokuTraducoes.Services.Profiles;
 
 namespace TsundokuTraducoes.Tests.Services.AppServices.Obra
 {
-    public class ObrasAppServiceTestes
+    public class ObraAppServiceTestes
     {
         private readonly IMapper _mapper;
         private readonly Mock<IObrasService> _obrasServiceMock;
-        private readonly Mock<IImagemAppService> _imagemAppServiceMock;
         private readonly Mock<IGeneroDeParaAppService> _generoDeParaAppServiceMock;
 
         private readonly ObrasAppService _obrasAppService;
 
-        public ObrasAppServiceTestes()
+        public ObraAppServiceTestes()
         {
             var config = new MapperConfiguration(cfg =>
             {

--- a/TsundokuTraducoes.Tests/Services/AppServices/ObrasAppServiceTestes.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/ObrasAppServiceTestes.cs
@@ -1,5 +1,8 @@
 ﻿using AutoMapper;
+using HttpContextMoq;
+using HttpContextMoq.Extensions;
 using Moq;
+using TsundokuTraducoes.Api.Helpers;
 using TsundokuTraducoes.Domain.Interfaces.Services;
 using TsundokuTraducoes.Entities.Entities.Obra;
 using TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
@@ -152,6 +155,92 @@ namespace TsundokuTraducoes.Tests.Services.AppServices
             Assert.Equal(banner, listaRetornoComic[0].UrlBanner);
             Assert.Equal("Aventura", listaRetornoComic[0].ListaGeneros[0]);
             Assert.Equal("Fantasia", listaRetornoComic[0].ListaGeneros[1]);
+        }
+
+        [Fact]
+        public void RetornaNovelsRecentes_DeveRetornarListaNovelsRecentes()
+        {
+            // Arrange
+            var dicionarioObrasRecentes = new Dictionary<string, DateTime>
+            {
+                { "Obra_1", new DateTime(2025, 04, 05, 00, 00, 01) },
+                { "Obra_4", new DateTime(2025, 04, 05, 00, 00, 03) },
+                { "Obra_5", new DateTime(2025, 04, 05, 00, 00, 07) },
+                { "Obra_2", new DateTime(2025, 04, 05, 00, 00, 10) },
+                { "Obra_3", new DateTime(2025, 04, 05, 00, 00, 15) },
+                { "Obra_6", new DateTime(2025, 04, 05, 00, 00, 30) }
+            };
+
+            var appServicesFactory = new AppServicesFactory();
+            var listaNovelsRecentes = appServicesFactory.GerarListaNovelsRecentes(dicionarioObrasRecentes);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/api/obras/novels/recentes";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Mock
+            var retornoNovelsRecentes = new List<RetornoNovelsRecentes>();
+
+            listaNovelsRecentes
+                .ForEach(novel => retornoNovelsRecentes.Add(
+                        _obrasAppServiceMock.TrataRetornoNovelRecentes(novel)
+                    )
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoNovelsRecentes(httpContext, retornoNovelsRecentes, null, null);
+
+            var numeroDeCamposDaListaObrasRecomendas = objetoRetorno.Data.First().GetType().GetProperties().Length;
+
+            // Assert
+            Assert.Equal(13, numeroDeCamposDaListaObrasRecomendas);
+            Assert.Equal("Obra_6", objetoRetorno.Data[0].Titulo);
+            Assert.Equal("Obra_2", objetoRetorno.Data[2].Titulo);
+            Assert.Equal("Obra_4", objetoRetorno.Data[4].Titulo);
+        }
+
+        [Fact]
+        public void RetornaComicsRecentes_DeveRetornarListaComicsRecentes()
+        {
+            // Arrange
+            var dicionarioObrasRecentes = new Dictionary<string, DateTime>
+            {
+                { "Obra_1", new DateTime(2025, 04, 05, 00, 00, 01) },
+                { "Obra_4", new DateTime(2025, 04, 05, 00, 00, 03) },
+                { "Obra_5", new DateTime(2025, 04, 05, 00, 00, 07) },
+                { "Obra_2", new DateTime(2025, 04, 05, 00, 00, 10) },
+                { "Obra_3", new DateTime(2025, 04, 05, 00, 00, 15) },
+                { "Obra_6", new DateTime(2025, 04, 05, 00, 00, 30) }
+            };
+
+            var appServicesFactory = new AppServicesFactory();
+            var listaComicsRecentes = appServicesFactory.GerarListaComicsRecentes(dicionarioObrasRecentes);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/api/obras/comics/recentes";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Mock
+            var retornoComicsRecentes = new List<RetornoComicsRecentes>();
+
+            listaComicsRecentes
+                .ForEach(comic => retornoComicsRecentes.Add(
+                        _obrasAppServiceMock.TrataRetornoComicRecentes(comic)
+                    )
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoComicsRecentes(httpContext, retornoComicsRecentes, null, null);
+
+            var numeroDeCamposDaListaObrasRecomendas = objetoRetorno.Data.First().GetType().GetProperties().Length;
+
+            // Assert
+            Assert.Equal(13, numeroDeCamposDaListaObrasRecomendas);
+            Assert.Equal("Obra_6", objetoRetorno.Data[0].Titulo);
+            Assert.Equal("Obra_2", objetoRetorno.Data[2].Titulo);
+            Assert.Equal("Obra_4", objetoRetorno.Data[4].Titulo);
         }
     }
 }

--- a/TsundokuTraducoes/Controllers/ObrasController.cs
+++ b/TsundokuTraducoes/Controllers/ObrasController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using TsundokuTraducoes.Api.Helpers;
 using TsundokuTraducoes.Helpers.DTOs.Public.Request;
 using TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
+using TsundokuTraducoes.Helpers.DTOs.Public.Retorno.Response;
 using TsundokuTraducoes.Helpers.Validacao;
 using TsundokuTraducoes.Services.AppServices.Interfaces;
 
@@ -33,14 +34,14 @@ namespace TsundokuTraducoes.Api.Controllers
         }
 
         [HttpGet("api/obras/novels/recentes")]
-        [ProducesResponseType(typeof(List<RetornoObras>), statusCode: 200)]
-        public async Task<IActionResult> ObterNovelsRecentes([FromQuery] RequestObras requestObras)
+        [ProducesResponseType(typeof(ObjetoRetornoNovelsRecentes), statusCode: 200)]
+        public async Task<IActionResult> ObterNovelsRecentes([FromQuery] int? skip, int? take)
         {
-            var capitulos = await _obrasAppServices.ObterListaNovelsRecentes();
-            if (capitulos.Count == 0)
+            var novels = await _obrasAppServices.ObterListaNovelsRecentes();
+            if (novels.Count == 0)
                 return NoContent();
 
-            var objetoRetorno = RequestHelper.CriarObjetoRetonoObras(HttpContext, capitulos, requestObras);
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoNovelsRecentes(HttpContext, novels, skip, take);
             return Ok(objetoRetorno);
         }
 
@@ -79,14 +80,14 @@ namespace TsundokuTraducoes.Api.Controllers
         }
 
         [HttpGet("api/obras/comics/recentes")]
-        [ProducesResponseType(typeof(List<RetornoObras>), statusCode: 200)]
-        public async Task<IActionResult> ObterComicsRecentes([FromQuery] RequestObras requestObras)
+        [ProducesResponseType(typeof(ObjetoRetornoComicsRecentes), statusCode: 200)]
+        public async Task<IActionResult> ObterComicsRecentes([FromQuery] int? skip, int? take)
         {
-            var capitulos = await _obrasAppServices.ObterListaComicsRecentes();
-            if (capitulos.Count == 0)
+            var comics = await _obrasAppServices.ObterListaComicsRecentes();
+            if (comics.Count == 0)
                 return NoContent();
 
-            var objetoRetorno = RequestHelper.CriarObjetoRetonoObras(HttpContext, capitulos, requestObras);
+            var objetoRetorno = RequestHelper.CriarObjetoRetonoComicsRecentes(HttpContext, comics, skip, take);
             return Ok(objetoRetorno);
         }
 

--- a/TsundokuTraducoes/Helpers/RequestHelper.cs
+++ b/TsundokuTraducoes/Helpers/RequestHelper.cs
@@ -272,6 +272,11 @@ namespace TsundokuTraducoes.Api.Helpers
 
         public static ObjetoRetornoNovelsRecentes CriarObjetoRetonoNovelsRecentes(HttpContext httpContext, List<RetornoNovelsRecentes> listaNovelsRecentes, int? skip, int? take)
         {
+            if (!skip.HasValue && !take.HasValue)
+            {
+                return new ObjetoRetornoNovelsRecentes { Anterior = null, Proxima = null, Data = listaNovelsRecentes, Total = listaNovelsRecentes.Count };
+            }
+
             var itensPorPagina = ValidacaoRequest.RetornaTakeTratado(take);
             var itensPulados = ValidacaoRequest.RetornaSkipTratado(skip, itensPorPagina);
 
@@ -289,6 +294,11 @@ namespace TsundokuTraducoes.Api.Helpers
 
         public static ObjetoRetornoComicsRecentes CriarObjetoRetonoComicsRecentes(HttpContext httpContext, List<RetornoComicsRecentes> listaComicsRecentes, int? skip, int? take)
         {
+            if (!skip.HasValue && !take.HasValue)
+            {
+                return new ObjetoRetornoComicsRecentes { Anterior = null, Proxima = null, Data = listaComicsRecentes, Total = listaComicsRecentes.Count };
+            }
+
             var itensPorPagina = ValidacaoRequest.RetornaTakeTratado(take);
             var itensPulados = ValidacaoRequest.RetornaSkipTratado(skip, itensPorPagina);
 

--- a/TsundokuTraducoes/Helpers/RequestHelper.cs
+++ b/TsundokuTraducoes/Helpers/RequestHelper.cs
@@ -270,6 +270,40 @@ namespace TsundokuTraducoes.Api.Helpers
             return new ObjetoRetornoGenerosCadastradosResponse { Anterior = anterior, Proxima = proxima, Data = dados, Total = total };
         }
 
+        public static ObjetoRetornoNovelsRecentes CriarObjetoRetonoNovelsRecentes(HttpContext httpContext, List<RetornoNovelsRecentes> listaNovelsRecentes, int? skip, int? take)
+        {
+            var itensPorPagina = ValidacaoRequest.RetornaTakeTratado(take);
+            var itensPulados = ValidacaoRequest.RetornaSkipTratado(skip, itensPorPagina);
+
+            var dados = listaNovelsRecentes.Skip(itensPulados).Take(itensPorPagina).ToList();
+            var total = listaNovelsRecentes.Count;
+
+            var request = httpContext.Request;
+            var url = $"{request.Scheme}://{request.Host}{request.Path}";
+
+            string proxima = RetornaLinkPaginacaoProxima(itensPorPagina, itensPulados, dados, url);
+            string anterior = RetornaLinkPaginacaoAnterior(itensPorPagina, itensPulados, url);
+
+            return new ObjetoRetornoNovelsRecentes { Total = total, Proxima = proxima, Anterior = anterior, Data = dados };
+        }
+
+        public static ObjetoRetornoComicsRecentes CriarObjetoRetonoComicsRecentes(HttpContext httpContext, List<RetornoComicsRecentes> listaComicsRecentes, int? skip, int? take)
+        {
+            var itensPorPagina = ValidacaoRequest.RetornaTakeTratado(take);
+            var itensPulados = ValidacaoRequest.RetornaSkipTratado(skip, itensPorPagina);
+
+            var dados = listaComicsRecentes.Skip(itensPulados).Take(itensPorPagina).ToList();
+            var total = listaComicsRecentes.Count;
+
+            var request = httpContext.Request;
+            var url = $"{request.Scheme}://{request.Host}{request.Path}";
+
+            string proxima = RetornaLinkPaginacaoProxima(itensPorPagina, itensPulados, dados, url);
+            string anterior = RetornaLinkPaginacaoAnterior(itensPorPagina, itensPulados, url);
+
+            return new ObjetoRetornoComicsRecentes { Total = total, Proxima = proxima, Anterior = anterior, Data = dados };
+        }
+
         private static string RetornaLinkPaginacaoAnterior(int itensPorPagina, int itensPulados, string url)
         {
             string anterior = null;


### PR DESCRIPTION
## Descreva as mudanças feitas nessa PR:
- Corrigido e ajustados retornos das obras nas classes e interfaces:
  - ObrasRepository.cs
  - IObrasRepository.cs
  - ObrasServices.cs
  - IObrasServices
- Criados objetos para retorno e tratamento das obras recentes:
  - ObjetoRetornoComicsRecentes.cs
  - ObjetoRetornoNovelsRecentes.cs
  - RetornoComicsRecentes.cs
  - RetornoNovelsRecentes.cs
  - ObrasAppService.cs
  - IObrasAppService.cs
- Adicionado novos profiles para mapeamento na classe:
  - ObrasProfile.cs
- Criados mocks para testes na classe:
  - AppServicesFactory.cs
- Realizado ajuste na classe:
  - ObraAppServiceTestes.cs
- Criados testes para retorno das novels e comics recentes na classe:
  - ObrasAppServiceTestes.cs
- Realizado ajustes de retorno na classe: 
  - ObrasController.cs
- Criados métodos para retorno dos dados na classe:
  - RequestHelper.cs

### Observações
- Foi feito essas alterações para duas rotas, mesmo que na issue tenha sido solicitado apenas uma, como foi mexido em postos semelhantes e praticamente iguais, tomei a iniciativa em fazer ambos os endpoints atá para adiantar o nosso processo ^^
- Foi corrigido os parâmetros de entrada na queryString, tendo agora apenas o skip e take para fazer a paginação e com valor padrão de retorno. Caso não informado traz a listagem toda e sem cotrole se foi publicado ou não.
- Regra de retorno para a listagem é ter ao menos um volume e um capítulo cadastrado.

## Ela resolve alguma issue? Informe o número:
#65 

## Preencha o checklist antes de enviar a PR (delete o que não usar):
- [x] New feature (adiciona nova funcionalidade).
- [x] Esta PR possui teste inclusos.