### PR TITLE
PR com adicão de nova rota para retorno capítulos comics passando slug obra

### DIFF
--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/Response/ObjetoRetornoCapitulosPorSlugComics.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/Response/ObjetoRetornoCapitulosPorSlugComics.cs
@@ -1,0 +1,9 @@
+﻿namespace TsundokuTraducoes.Helpers.DTOs.Public.Retorno.Response;
+
+public class ObjetoRetornoCapitulosPorSlugComics
+{
+    public string Proxima { get; set; }
+    public string Anterior { get; set; }
+    public List<RetornoCapituloComic> Data { get; set; }
+    public int Total { get; set; }
+}

--- a/TsundokuTraducoes.Helpers/Validacao/ValidacaoRequest.cs
+++ b/TsundokuTraducoes.Helpers/Validacao/ValidacaoRequest.cs
@@ -74,6 +74,12 @@ namespace TsundokuTraducoes.Helpers.Validacao
             return obrasPorPagina == null ? valorObrasPorPagina : obrasPorPagina.GetValueOrDefault();
         }
 
+        public static int RetornaTakeCapitulosTratado(int? obrasPorPagina)
+        {
+            var valorObrasPorPagina = 15;
+            return obrasPorPagina == null ? valorObrasPorPagina : obrasPorPagina.GetValueOrDefault();
+        }
+
         public static int RetornaSkipTratado(int? pagina, int obrasPorPagina)
         {
             return pagina == null ? 0 : (pagina.GetValueOrDefault() < 0 ? 0 : pagina.GetValueOrDefault());

--- a/TsundokuTraducoes.Services/AppServices/CapituloComicAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/CapituloComicAppService.cs
@@ -56,6 +56,24 @@ namespace TsundokuTraducoes.Services.AppServices
             return Result.Ok(listaRetornoCapituloComic);
         }
 
+        public async Task<Result<List<RetornoCapituloComic>>> ObterListaCapitulosComicPorSlugObra(string slugObra)
+        {
+            var listaRetornoCapituloComic = new List<RetornoCapituloComic>();
+
+            var obra = obraservice.RetornaComicPorSlug(slugObra);
+            if (obra == null)
+                return Result.Fail("Obra não encontrada!");
+
+            var listaCapituloComic = await service.ObterCapitulosComicPorSlugObra(slugObra);
+
+            foreach (var capituloComic in listaCapituloComic)
+            {
+                listaRetornoCapituloComic.Add(TrataRetornoCapituloComic(capituloComic));
+            }
+
+            return Result.Ok(listaRetornoCapituloComic);
+        }
+
         public Result ValidaExisteCapituloNaLista(List<RetornoCapituloComic> capitulos, Guid idCapitulo)
         {
 

--- a/TsundokuTraducoes.Services/AppServices/Interfaces/ICapituloComicAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/Interfaces/ICapituloComicAppService.cs
@@ -7,6 +7,7 @@ namespace TsundokuTraducoes.Services.AppServices.Interfaces
     {
         Task<Result<List<RetornoCapituloComic>>> ObterCapitulosComicPorIdObraEIdCapitulo(Guid idObra, Guid idCapitulo);
         Task<Result<List<RetornoCapituloComic>>> ObterCapitulosComicPorSlugObraEIdCapitulo(string slugObra, Guid idCapitulo);
+        Task<Result<List<RetornoCapituloComic>>> ObterListaCapitulosComicPorSlugObra(string slugObra);
         Result ValidaExisteCapituloNaLista(List<RetornoCapituloComic> capitulos, Guid idCapitulo);
     }
 }

--- a/TsundokuTraducoes.Tests/Services/AppServices/Capitulo/CapituloAppServiceTestes.cs
+++ b/TsundokuTraducoes.Tests/Services/AppServices/Capitulo/CapituloAppServiceTestes.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using FluentResults;
 using HttpContextMoq;
 using HttpContextMoq.Extensions;
 using Moq;
@@ -53,7 +52,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
 
         #region => TESTES CAPITULO COMIC APP SERVICE
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapitulo_ComLinksParaProximoEAnterior_NaBuscaPorIdCapituloEIdbra))]
+        [Trait("Services", "AppService - CapituloComics")]
         public void DeveRetornarCapitulo_ComLinksParaProximoEAnterior_NaBuscaPorIdCapituloEIdbra()
         {
             // Arrange
@@ -94,7 +94,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Contains($"{comic.Id}/{listaIdsCapitulos[0]}", objetoRetorno.Anterior);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapitulo_ComLinksParaProximoEAnteriorNull_NaBuscaPorIdCapituloEIdbra))]
+        [Trait("Services", "AppService - CapituloComics")]
         public void DeveRetornarCapitulo_ComLinksParaProximoEAnteriorNull_NaBuscaPorIdCapituloEIdbra()
         {
             // Arrange
@@ -135,7 +136,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Null(objetoRetorno.Anterior);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapitulo_ComLinksParaAnteriorEProximoNull_NaBuscaPorIdCapituloEIdbra))]
+        [Trait("Services", "AppService - CapituloComics")]
         public void DeveRetornarCapitulo_ComLinksParaAnteriorEProximoNull_NaBuscaPorIdCapituloEIdbra()
         {
             // Arrange
@@ -176,7 +178,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Null(objetoRetorno.Proxima);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarFalse_QuandoCapituloNaoEncontrado_NaBuscaPorIdCapituloEIdbra))]
+        [Trait("Services", "AppService - CapituloComics")]
         public void DeveRetornarFalse_QuandoCapituloNaoEncontrado_NaBuscaPorIdCapituloEIdbra()
         {
             // Arrange
@@ -216,7 +219,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Contains("Capítulo não encontrado!", result.Errors[0].Message);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarNull_QuandoObraNaoEncontrada_NaBuscaPorIdCapituloEIdbra))]
+        [Trait("Services", "AppService - CapituloComics")]
         public async Task DeveRetornarNull_QuandoObraNaoEncontrada_NaBuscaPorIdCapituloEIdbra()
         {
             // Arrange
@@ -247,7 +251,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
         }
 
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapitulo_ComLinksParaProximoEAnterior_NaBuscaPorIdCapituloESlugObra))]
+        [Trait("Services", "AppService - CapituloComics")]
         public void DeveRetornarCapitulo_ComLinksParaProximoEAnterior_NaBuscaPorIdCapituloESlugObra()
         {
             // Arrange
@@ -290,7 +295,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Contains($"{comic.Slug}/{listaIdsCapitulos[0]}", objetoRetorno.Anterior);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapitulo_ComLinksParaProximoEAnteriorNull_NaBuscaPorIdCapituloESlugObra))]
+        [Trait("Services", "AppService - CapituloComics")]
         public void DeveRetornarCapitulo_ComLinksParaProximoEAnteriorNull_NaBuscaPorIdCapituloESlugObra()
         {
             // Arrange
@@ -333,7 +339,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Null(objetoRetorno.Anterior);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapitulo_ComLinksParaAnteriorEProximoNull_NaBuscaPorIdCapituloESlugObra))]
+        [Trait("Services", "AppService - CapituloComics")]
         public void DeveRetornarCapitulo_ComLinksParaAnteriorEProximoNull_NaBuscaPorIdCapituloESlugObra()
         {
             // Arrange
@@ -376,7 +383,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Null(objetoRetorno.Proxima);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarFalse_QuandoCapituloNaoEncontrado_NaBuscaPorIdCapituloESlugObra))]
+        [Trait("Services", "AppService - CapituloComics")]
         public void DeveRetornarFalse_QuandoCapituloNaoEncontrado_NaBuscaPorIdCapituloESlugObra()
         {
             // Arrange
@@ -418,7 +426,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Contains("Capítulo não encontrado!", result.Errors[0].Message);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarNull_QuandoObraNaoEncontrada_NaBuscaPorIdCapituloESlugObra))]
+        [Trait("Services", "AppService - CapituloComics")]
         public async Task DeveRetornarNull_QuandoObraNaoEncontrada_NaBuscaPorIdCapituloESlugObra()
         {
             // Arrange
@@ -449,11 +458,183 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Contains("Obra não encontrada!", result.Errors[0].Message);
         }
 
+
+        [Fact(DisplayName = nameof(DeveRetornarListaCapitulos_ComLinksParaProximoEAnterior_NaBuscaPorSlugObra))]
+        [Trait("Services", "AppService - CapituloComics")]
+        public void DeveRetornarListaCapitulos_ComLinksParaProximoEAnterior_NaBuscaPorSlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023"),
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var capituloAppServiceFactory = new CapituloAppServiceFactoryTestes();
+            Comic comic = capituloAppServiceFactory.GerarComic(IdObra, slugObra);
+            VolumeComic volumeComic = capituloAppServiceFactory.GerarVolumeComic(IdObra);
+            List<CapituloComic> listaCapituloComic = capituloAppServiceFactory.GerarListaCapituloComic(listaIdsCapitulos);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Slug}?skip=1";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoCapituloComic = new List<RetornoCapituloComic>();
+
+            listaCapituloComic
+                .ForEach(capituloComic => retornoListaRetornoCapituloComic
+                    .Add(_capituloComicAppService
+                        .TrataRetornoCapituloComic(capituloComic))
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetornoCapitulosPorSlugObra(httpContext, retornoListaRetornoCapituloComic, 1, null);
+
+            Assert.Equal(15, objetoRetorno.Data.Count);
+            Assert.Equal(16, objetoRetorno.Total);
+            Assert.Contains($"{comic.Slug}?Skip=16&Take=15", objetoRetorno.Proxima);
+            Assert.Contains($"{comic.Slug}?Skip=0&Take=15", objetoRetorno.Anterior);
+        }
+
+        [Fact(DisplayName = nameof(DeveRetornarListaCapitulos_ComLinksParaProximoEAnterior_NaBuscaPorSlugObra))]
+        [Trait("Services", "AppService - CapituloComics")]
+        public void DeveRetornarListaCapitulos_ComLinksParaProximoEAnteriorNull_NaBuscaPorSlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023"),
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var capituloAppServiceFactory = new CapituloAppServiceFactoryTestes();
+            Comic comic = capituloAppServiceFactory.GerarComic(IdObra, slugObra);
+            VolumeComic volumeComic = capituloAppServiceFactory.GerarVolumeComic(IdObra);
+            List<CapituloComic> listaCapituloComic = capituloAppServiceFactory.GerarListaCapituloComic(listaIdsCapitulos);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Slug}?skip=0&take=15";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoCapituloComic = new List<RetornoCapituloComic>();
+
+            listaCapituloComic
+                .ForEach(capituloComic => retornoListaRetornoCapituloComic
+                    .Add(_capituloComicAppService
+                        .TrataRetornoCapituloComic(capituloComic))
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetornoCapitulosPorSlugObra(httpContext, retornoListaRetornoCapituloComic, 0, 15);
+
+            Assert.Equal(slugObra, comic.Slug);
+            Assert.Equal(15, objetoRetorno.Data.Count);
+            Assert.Equal(16, objetoRetorno.Total);
+            Assert.Contains($"{comic.Slug}?Skip=15&Take=15", objetoRetorno.Proxima);
+            Assert.Null(objetoRetorno.Anterior);
+        }
+
+        [Fact(DisplayName = nameof(DeveRetornarListaCapitulos_ComLinksParaProximoEAnterior_NaBuscaPorSlugObra))]
+        [Trait("Services", "AppService - CapituloComics")]
+        public void DeveRetornarListaCapitulos_ComLinksParaAnteriorEProximoNull_NaBuscaPorSlugObra()
+        {
+            // Arrange
+            var IdObra = Guid.Parse("00000000-1111-2222-3333-444444444444");
+            var slugObra = "slug-comic-teste";
+
+            List<Guid> listaIdsCapitulos =
+            [
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023"),
+                Guid.Parse("08dba651-ec33-4964-8f67-eecd4cbaea50"),
+                Guid.Parse("08dd6104-d05d-49a9-8a66-62ca7b07acdc"),
+                Guid.Parse("08dd6b39-c3d8-48a9-86fe-a2146c233c9f"),
+                Guid.Parse("08dd6b39-cbd2-44a1-8847-30d8228716e5"),
+                Guid.Parse("08dd6b3c-35f9-4f1d-829c-ca86d5f95cf2"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023"),
+                Guid.Parse("08dd6b3c-3c21-4e49-84ec-d3981a2e7f8c"),
+                Guid.Parse("08dd6b3c-428f-485f-899f-dbad73d19023")
+            ];
+
+            var capituloAppServiceFactory = new CapituloAppServiceFactoryTestes();
+            Comic comic = capituloAppServiceFactory.GerarComic(IdObra, slugObra);
+            VolumeComic volumeComic = capituloAppServiceFactory.GerarVolumeComic(IdObra);
+            List<CapituloComic> listaCapituloComic = capituloAppServiceFactory.GerarListaCapituloComic(listaIdsCapitulos);
+
+            var scheme = "https";
+            var host = "localhost";
+            var path = $"/mock/{comic.Slug}?skip=15&take=15";
+            var url = $"{scheme}://{host}/{path}";
+            var httpContext = new HttpContextMock().SetupUrl(url);
+
+            // Assert
+            var retornoListaRetornoCapituloComic = new List<RetornoCapituloComic>();
+
+            listaCapituloComic
+                .ForEach(capituloComic => retornoListaRetornoCapituloComic
+                    .Add(_capituloComicAppService
+                        .TrataRetornoCapituloComic(capituloComic))
+                );
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetornoCapitulosPorSlugObra(httpContext, retornoListaRetornoCapituloComic, 15, 15);
+
+            Assert.Equal(slugObra, comic.Slug);
+            Assert.Single(objetoRetorno.Data);
+            Assert.Equal(16, objetoRetorno.Total);
+            Assert.Contains($"{comic.Slug}?Skip=0&Take=15", objetoRetorno.Anterior);
+            Assert.Null(objetoRetorno.Proxima);
+        }
+
         #endregion
 
         #region => TESTES CAPITULO NOVEL APP SERVICE
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapituloNovel_ComLinksParaProximoEAnterior_NaBuscaPorIdCapituloEIdbra))]
+        [Trait("Services", "AppService - CapituloNovels")]
         public void DeveRetornarCapituloNovel_ComLinksParaProximoEAnterior_NaBuscaPorIdCapituloEIdbra()
         {
             // Arrange
@@ -494,7 +675,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Contains($"{novel.Id}/{listaIdsCapitulos[0]}", objetoRetorno.Anterior);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapituloNovel_ComLinksParaProximoEAnteriorNull_NaBuscaPorIdCapituloEIdbra))]
+        [Trait("Services", "AppService - CapituloNovels")]
         public void DeveRetornarCapituloNovel_ComLinksParaProximoEAnteriorNull_NaBuscaPorIdCapituloEIdbra()
         {
             // Arrange
@@ -535,7 +717,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Null(objetoRetorno.Anterior);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapituloNovel_ComLinksParaAnteriorEProximoNull_NaBuscaPorIdCapituloEIdbra))]
+        [Trait("Services", "AppService - CapituloNovels")]
         public void DeveRetornarCapituloNovel_ComLinksParaAnteriorEProximoNull_NaBuscaPorIdCapituloEIdbra()
         {
             // Arrange
@@ -576,7 +759,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Null(objetoRetorno.Proxima);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarFalseCapituloNovel_QuandoCapituloNaoEncontrado_NaBuscaPorIdCapituloEIdbra))]
+        [Trait("Services", "AppService - CapituloNovels")]
         public void DeveRetornarFalseCapituloNovel_QuandoCapituloNaoEncontrado_NaBuscaPorIdCapituloEIdbra()
         {
             // Arrange
@@ -616,7 +800,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Contains("Capítulo não encontrado!", result.Errors[0].Message);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarNullCapituloNovel_QuandoObraNaoEncontrada_NaBuscaPorIdCapituloEIdbra))]
+        [Trait("Services", "AppService - CapituloNovels")]
         public async Task DeveRetornarNullCapituloNovel_QuandoObraNaoEncontrada_NaBuscaPorIdCapituloEIdbra()
         {
             // Arrange
@@ -646,7 +831,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Contains("Obra não encontrada!", result.Errors[0].Message);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapituloNovel_ComLinksParaProximoEAnterior_NaBuscaPorIdCapituloESlugObra))]
+        [Trait("Services", "AppService - CapituloNovels")]
         public void DeveRetornarCapituloNovel_ComLinksParaProximoEAnterior_NaBuscaPorIdCapituloESlugObra()
         {
             // Arrange
@@ -688,7 +874,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Contains($"{novel.Slug}/{listaIdsCapitulos[0]}", objetoRetorno.Anterior);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapituloNovel_ComLinksParaProximoEAnteriorNull_NaBuscaPorIdCapituloESlugObra))]
+        [Trait("Services", "AppService - CapituloNovels")]
         public void DeveRetornarCapituloNovel_ComLinksParaProximoEAnteriorNull_NaBuscaPorIdCapituloESlugObra()
         {
             // Arrange
@@ -730,7 +917,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Null(objetoRetorno.Anterior);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarCapituloNovel_ComLinksParaAnteriorEProximoNull_NaBuscaPorIdCapituloESlugObra))]
+        [Trait("Services", "AppService - CapituloNovels")]
         public void DeveRetornarCapituloNovel_ComLinksParaAnteriorEProximoNull_NaBuscaPorIdCapituloESlugObra()
         {
             // Arrange
@@ -772,7 +960,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Null(objetoRetorno.Proxima);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarFalseCapituloNovel_QuandoCapituloNaoEncontrado_NaBuscaPorIdCapituloESlugObra))]
+        [Trait("Services", "AppService - CapituloNovels")]
         public void DeveRetornarFalseCapituloNovel_QuandoCapituloNaoEncontrado_NaBuscaPorIdCapituloESlugObra()
         {
             // Arrange
@@ -813,7 +1002,8 @@ namespace TsundokuTraducoes.Tests.Services.AppServices.Capitulo
             Assert.Contains("Capítulo não encontrado!", result.Errors[0].Message);
         }
 
-        [Fact]
+        [Fact(DisplayName = nameof(DeveRetornarNullCapituloNovel_QuandoObraNaoEncontrada_NaBuscaPorIdCapituloESlugObra))]
+        [Trait("Services", "AppService - CapituloNovels")]
         public async Task DeveRetornarNullCapituloNovel_QuandoObraNaoEncontrada_NaBuscaPorIdCapituloESlugObra()
         {
             // Arrange

--- a/TsundokuTraducoes/Controllers/GeneroController.cs
+++ b/TsundokuTraducoes/Controllers/GeneroController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using TsundokuTraducoes.Api.Helpers;
 using TsundokuTraducoes.Helpers.DTOs.Admin;

--- a/TsundokuTraducoes/Controllers/Publico/comic/CapitulosComicsController.cs
+++ b/TsundokuTraducoes/Controllers/Publico/comic/CapitulosComicsController.cs
@@ -31,5 +31,19 @@ namespace TsundokuTraducoes.Api.Controllers.Publico.manga
             var objetoRetorno = RequestHelper.CriarObjetoRetonoCapitulosPorSlugComics(HttpContext, result.Value, idCapitulo);
             return Ok(objetoRetorno);
         }
+
+        [HttpGet("api/comics/slug/{slugObra}")]
+        public async Task<IActionResult> ObterListaCapitulosComicPorSlugObra(string slugObra, [FromQuery] int? skip, int? take)
+        {
+            var result = await service.ObterListaCapitulosComicPorSlugObra(slugObra);
+            if (result.IsFailed)
+                return NotFound(result.Errors[0].Message);
+
+            if (result.Value == null || result.Value.Count == 0)
+                return NoContent();
+
+            var objetoRetorno = RequestHelper.CriarObjetoRetornoCapitulosPorSlugObra(HttpContext, result.Value, skip, take);
+            return Ok(objetoRetorno);
+        }
     }
 }

--- a/TsundokuTraducoes/Helpers/RequestHelper.cs
+++ b/TsundokuTraducoes/Helpers/RequestHelper.cs
@@ -332,6 +332,28 @@ namespace TsundokuTraducoes.Api.Helpers
             return new ObjetoRetornoGenerosResponse  { Total = total, Proxima = proxima, Anterior = anterior, Data = dados };
         }
 
+        public static ObjetoRetornoCapitulosPorSlugComics CriarObjetoRetornoCapitulosPorSlugObra(HttpContext httpContext, List<RetornoCapituloComic> listaRetornoCapituloComic, int? skip, int? take)
+        {
+            if (!skip.HasValue && !take.HasValue)
+            {
+                return new ObjetoRetornoCapitulosPorSlugComics { Anterior = null, Proxima = null, Data = listaRetornoCapituloComic, Total = listaRetornoCapituloComic.Count };
+            }
+
+            var itensPorPagina = ValidacaoRequest.RetornaTakeCapitulosTratado(take);
+            var itensPulados = ValidacaoRequest.RetornaSkipTratado(skip, itensPorPagina);
+
+            var dados = listaRetornoCapituloComic.Skip(itensPulados).Take(itensPorPagina).ToList();
+            var total = listaRetornoCapituloComic.Count;
+
+            var request = httpContext.Request;
+            var url = $"{request.Scheme}://{request.Host}{request.Path}";
+
+            string proxima = RetornaLinkPaginacaoProxima(itensPorPagina, itensPulados, dados, url);
+            string anterior = RetornaLinkPaginacaoAnterior(itensPorPagina, itensPulados, url);
+
+            return new ObjetoRetornoCapitulosPorSlugComics { Total = total, Proxima = proxima, Anterior = anterior, Data = dados };
+        }
+
         private static string RetornaLinkPaginacaoAnterior(int itensPorPagina, int itensPulados, string url)
         {
             string anterior = null;


### PR DESCRIPTION
## Descreva as mudanças feitas nessa PR:
- Criada classe: ObjetoRetornoCapitulosPorSlugComics
- Criado método: RetornaTakeCapitulosTratado
- Criado método: ObterListaCapitulosComicPorSlugObra
  -  Interface e classe: ICapituloComicAppService.cs / CapituloComicAppService.cs
- Adicionados testes unitários para a listagem de capítulos e adicionados dataannotations para visualização dos testes
  - Classe: CapituloAppServiceTestes.cs 
- Adicionada nova rota
  -  Classe: CapitulosComicsController.cs
- Criado método CriarObjetoRetornoCapitulosPorSlugObra
  - Classe RequestHelper.cs|
  
## Ela resolve alguma issue? Informe o número:
[#67](https://github.com/tsundokuapp/tsundoku/issues/67)

## Preencha o checklist antes de enviar a PR (delete o que não usar):
- [x] New feature (adiciona nova funcionalidade).
- [x] Esta PR possui teste inclusos.