### PR TITLE
PR com nova rota para consultar obras via pesquisa título/título alternativo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@
 x64/
 [Bb]in/
 [Oo]bj/
+/TsundokuTraducoes.Auth.Api/appsettings.json

--- a/TsundokuTraducoes.Data/Repositories/ObrasRepository.cs
+++ b/TsundokuTraducoes.Data/Repositories/ObrasRepository.cs
@@ -494,5 +494,45 @@ namespace TsundokuTraducoes.Data.Repositories
 
             return listaGeneros;
         }
+
+        public async Task<List<RetornoObrasPesquisa>> ObterObrasPesquisa(string obra)
+        {
+            var query = (from comics in _context.Comics.AsNoTracking()
+                         where EF.Functions.Like(comics.Titulo.ToUpper(), $"%{obra.ToUpper()}%")
+                         || EF.Functions.Like(comics.TituloAlternativo.ToUpper(), $"%{obra.ToUpper()}%")
+                         select new
+                         {
+                             comics.Id,
+                             comics.Slug,
+                             comics.Titulo,
+                             comics.Alias,
+                             Capa = comics.ImagemCapaUltimoVolume
+                         })
+                        .Union(from novels in _context.Novels.AsNoTracking()
+                               where EF.Functions.Like(novels.Titulo.ToUpper(), $"%{obra.ToUpper()}%")
+                               || EF.Functions.Like(novels.TituloAlternativo.ToUpper(), $"%{obra.ToUpper()}%")
+                               select new
+                               {
+                                   novels.Id,
+                                   novels.Slug,
+                                   novels.Titulo,
+                                   novels.Alias,
+                                   Capa = novels.ImagemCapaUltimoVolume
+                               }
+                        );
+
+            var listaRetornoObrasPesquisa = await query
+                .Select(rc => new RetornoObrasPesquisa
+                {
+                    Id = rc.Id,
+                    Slug = rc.Slug,
+                    Titulo = rc.Titulo,
+                    Alias = rc.Alias,
+                    Capa = rc.Capa
+                })
+                .ToListAsync();
+
+            return listaRetornoObrasPesquisa;
+        }
     }
 }

--- a/TsundokuTraducoes.Data/Repositories/ObrasRepository.cs
+++ b/TsundokuTraducoes.Data/Repositories/ObrasRepository.cs
@@ -506,7 +506,9 @@ namespace TsundokuTraducoes.Data.Repositories
                              comics.Slug,
                              comics.Titulo,
                              comics.Alias,
-                             Capa = comics.ImagemCapaUltimoVolume
+                             Capa = comics.ImagemCapaUltimoVolume,
+                             Tipo = comics.TipoObra,
+                             Sinopse = comics.Sinopse
                          })
                         .Union(from novels in _context.Novels.AsNoTracking()
                                where EF.Functions.Like(novels.Titulo.ToUpper(), $"%{obra.ToUpper()}%")
@@ -517,7 +519,9 @@ namespace TsundokuTraducoes.Data.Repositories
                                    novels.Slug,
                                    novels.Titulo,
                                    novels.Alias,
-                                   Capa = novels.ImagemCapaUltimoVolume
+                                   Capa = novels.ImagemCapaUltimoVolume,
+                                   Tipo = novels.TipoObra,
+                                   novels.Sinopse
                                }
                         );
 
@@ -528,7 +532,9 @@ namespace TsundokuTraducoes.Data.Repositories
                     Slug = rc.Slug,
                     Titulo = rc.Titulo,
                     Alias = rc.Alias,
-                    Capa = rc.Capa
+                    Capa = rc.Capa,
+                    Tipo = rc.Tipo,
+                    Sinopse = rc.Sinopse
                 })
                 .ToListAsync();
 

--- a/TsundokuTraducoes.Domain/Interfaces/Repositories/IObrasRepository.cs
+++ b/TsundokuTraducoes.Domain/Interfaces/Repositories/IObrasRepository.cs
@@ -27,5 +27,7 @@ namespace TsundokuTraducoes.Domain.Interfaces.Repositories
         List<RetornoVolumes> ObterListaVolumeCapitulos(string idObra);
         Task<CapituloComic> ObterCapituloComicPorId(Guid id);
         Task<CapituloNovel> ObterCapituloNovelPorId(Guid id);
+
+        Task<List<RetornoObrasPesquisa>> ObterObrasPesquisa(string obra);
     }
 }

--- a/TsundokuTraducoes.Domain/Interfaces/Services/IObrasService.cs
+++ b/TsundokuTraducoes.Domain/Interfaces/Services/IObrasService.cs
@@ -23,5 +23,7 @@ namespace TsundokuTraducoes.Domain.Interfaces.Services
         List<RetornoVolumes> ObterListaVolumeCapitulos(string idObra);
         Task<CapituloComic> ObterCapituloComicPorId(Guid id);
         Task<CapituloNovel> ObterCapituloNovelPorId(Guid id);
+
+        Task<List<RetornoObrasPesquisa>> ObterObrasPesquisa(string obra);
     }
 }

--- a/TsundokuTraducoes.Domain/Services/ObrasServices.cs
+++ b/TsundokuTraducoes.Domain/Services/ObrasServices.cs
@@ -86,6 +86,11 @@ namespace TsundokuTraducoes.Domain.Services
         public async Task<CapituloNovel> ObterCapituloNovelPorId(Guid id)
         {
             return await _obrasRepository.ObterCapituloNovelPorId(id);
-        }       
+        }
+
+        public async Task<List<RetornoObrasPesquisa>> ObterObrasPesquisa(string obra)
+        {
+            return await _obrasRepository.ObterObrasPesquisa(obra);
+        }
     }
 }

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/Response/ObjetoRetornoObrasPesquisa.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/Response/ObjetoRetornoObrasPesquisa.cs
@@ -1,0 +1,8 @@
+﻿namespace TsundokuTraducoes.Helpers.DTOs.Public.Retorno.Response
+{
+    public class ObjetoRetornoObrasPesquisa
+    {
+        public List<RetornoObrasPesquisa> Data { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoObrasPesquisa.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoObrasPesquisa.cs
@@ -7,4 +7,6 @@ public class RetornoObrasPesquisa
     public string Titulo { get; set; }
     public string Alias { get; set; }
     public string Capa { get; set; }
+    public string Tipo { get; set; }
+    public string Sinopse { get; set; }
 }

--- a/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoObrasPesquisa.cs
+++ b/TsundokuTraducoes.Helpers/DTOs/Public/Retorno/RetornoObrasPesquisa.cs
@@ -1,0 +1,10 @@
+﻿namespace TsundokuTraducoes.Helpers.DTOs.Public.Retorno;
+
+public class RetornoObrasPesquisa
+{
+    public Guid Id { get; set; }
+    public string Slug { get; set; }
+    public string Titulo { get; set; }
+    public string Alias { get; set; }
+    public string Capa { get; set; }
+}

--- a/TsundokuTraducoes.Services/AppServices/Interfaces/IObrasAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/Interfaces/IObrasAppService.cs
@@ -22,5 +22,7 @@ namespace TsundokuTraducoes.Services.AppServices.Interfaces
         List<RetornoVolumes> ObterListaVolumeCapitulos(RequestObras requestObras);
         Task<RetornoCapituloComic> ObterCapituloComicPorId(Guid id);
         Task<RetornoCapituloNovel> ObterCapituloNovelPorId(Guid id);
+
+        Task<List<RetornoObrasPesquisa>> ObterObrasPesquisa(string obra);
     }
 }

--- a/TsundokuTraducoes.Services/AppServices/ObrasAppService.cs
+++ b/TsundokuTraducoes.Services/AppServices/ObrasAppService.cs
@@ -381,5 +381,10 @@ namespace TsundokuTraducoes.Services.AppServices
                 Id = obra.Id
             };
         }
+
+        public async Task<List<RetornoObrasPesquisa>> ObterObrasPesquisa(string obra)
+        {
+            return await _obrasService.ObterObrasPesquisa(obra);
+        }
     }
 }

--- a/TsundokuTraducoes/Controllers/ObrasController.cs
+++ b/TsundokuTraducoes/Controllers/ObrasController.cs
@@ -172,5 +172,16 @@ namespace TsundokuTraducoes.Api.Controllers
 
             return Ok(capituloNovel);
         }
+
+        [HttpGet("api/obras/pesquisa")]
+        [ProducesResponseType(typeof(ObjetoRetornoObrasPesquisa), statusCode: 200)]
+        public async Task<IActionResult> ObterObrasPesquisa([FromQuery] string obra)
+        {
+            var retorno = await _obrasAppServices.ObterObrasPesquisa(obra);
+            if (retorno.Count == 0)
+                return NoContent();
+
+            return Ok(new ObjetoRetornoObrasPesquisa { Data = retorno, Total = retorno.Count });
+        }
     }
 }


### PR DESCRIPTION
## Descreva as mudanças feitas nessa PR:
- Atualização gitignore
- Adicionado método ObterObrasPesquisa nas classes/interfaces:
  - ObrasRepository.cs
  - IObrasRepository.cs
  - IObrasService.cs
  - ObrasServices.cs
  - IObrasAppService.cs
  - ObrasAppService.cs
  - ObrasController.cs
- Criada classe ObjetoRetornoObrasPesquisa.cs
- Criada classe RetornoObrasPesquisa.cs

## Ela resolve alguma issue? Informe o número:
#96 

## Preencha o checklist antes de enviar a PR (delete o que não usar):
- [x] New feature (adiciona nova funcionalidade).